### PR TITLE
Enable running setup scripts with Python 3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -86,6 +86,11 @@ AC_PATH_PROG(ENV, env)
 AC_SUBST(ENV)
 
 # check python
+AC_ARG_WITH(python,
+    AS_HELP_STRING([--with-python[=PATH]],
+        [Select python2 or python3]),
+    [PYTHON=$with_python], []
+)
 AM_PATH_PYTHON([2.5])
 
 # --enable-boost

--- a/setup/dicttreeview.py
+++ b/setup/dicttreeview.py
@@ -172,13 +172,13 @@ class DictionaryTreeView(Gtk.TreeView):
         if prop.name == 'dictionaries':
             return self.get_dictionaries()
         else:
-            raise AttributeError, 'unknown property %s' % prop.name
+            raise AttributeError('unknown property %s' % prop.name)
 
     def do_set_property(self, prop, value):
         if prop.name == "dictionaries":
             self.set_dictionaries(value)
         else:
-            raise AttributeError, 'unknown property %s' % prop.name
+            raise AttributeError('unknown property %s' % prop.name)
 
 
 GObject.type_register(DictionaryTreeView)

--- a/setup/ibus-setup-libpinyin.in
+++ b/setup/ibus-setup-libpinyin.in
@@ -28,5 +28,5 @@ export IBUS_DATAROOTDIR=@datarootdir@
 export IBUS_LOCALEDIR=@localedir@
 export IBUS_PKGDATADIR=@prefix@/share/@PACKAGE@
 cd @prefix@/share/@PACKAGE@/setup/
-exec python main2.py $@
+exec @PYTHON@ main2.py $@
 

--- a/setup/main2.py
+++ b/setup/main2.py
@@ -21,6 +21,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+from __future__ import print_function
+
 import gettext
 
 import locale
@@ -268,8 +270,8 @@ class PreferencesDialog:
 
         def __correct_pinyin_toggled_cb(widget):
             val = widget.get_active()
-            map(lambda w: self.__builder.get_object(w[0]).set_sensitive(val),
-                self.__correct_pinyin_widgets)
+            for w in self.__correct_pinyin_widgets:
+                self.__builder.get_object(w[0]).set_sensitive(val)
         self.__correct_pinyin.connect("toggled", __correct_pinyin_toggled_cb)
 
         # init value
@@ -304,8 +306,8 @@ class PreferencesDialog:
 
         def __fuzzy_pinyin_toggled_cb(widget):
             val = widget.get_active()
-            map(lambda w: self.__builder.get_object(w[0]).set_sensitive(val),
-                self.__fuzzy_pinyin_widgets)
+            for w in self.__fuzzy_pinyin_widgets:
+                self.__builder.get_object(w[0]).set_sensitive(val)
         self.__fuzzy_pinyin.connect("toggled", __fuzzy_pinyin_toggled_cb)
 
         # init value
@@ -452,7 +454,7 @@ class PreferencesDialog:
         elif isinstance(val, str):
             var = GLib.Variant.new_string(val)
         else:
-            print >> sys.stderr, "val(%s) is not in support type." % repr(val)
+            print("val(%s) is not in support type." % repr(val), file=sys.stderr)
             return
 
         self.__values[name] = val


### PR DESCRIPTION
The default uses 'python'.
To use 'python3', ./configure --with-python=python3