### PR TITLE
Don't use sed -i

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -66,9 +66,10 @@ desktop_in_files = \
 desktop_files = $(desktop_in_files:.desktop.in=.desktop)
 
 $(desktop_files): $(desktop_in_files) Makefile
-	$(AM_V_GEN)$(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
-	sed -i -e 's|@libexecdir[@]|$(libexecdir)|g' \
-	-e 's|@pkgdatadir[@]|$(pkgdatadir)|g' $@
+	$(AM_V_GEN)$(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@.tmp
+	sed -e 's|@libexecdir[@]|$(libexecdir)|g' \
+	-e 's|@pkgdatadir[@]|$(pkgdatadir)|g' $@.tmp > $@
+	rm $@.tmp
 
 desktopdir=$(datadir)/applications
 desktop_DATA = $(desktop_files)


### PR DESCRIPTION
sed -i is a non-standard feature which may have different syntax or
meaning depending on the implementation. It is better to use a
temporary file instead of relying on a sed command implementing the
feature in the same way as GNU sed.

This fixes build failure on FreeBSD.