### PR TITLE
Improve and merge Cloud Input feature

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -181,6 +181,26 @@ fi
 
 AM_CONDITIONAL(IBUS_BUILD_LUA_EXTENSION, [test x"$enable_lua_extension" = x"yes"])
 
+# --enable-cloud-input-mode
+AC_ARG_ENABLE(cloud-input-mode,
+    AC_HELP_STRING([--enable-cloud-input-mode],
+        [add cloud candidates]),
+        [enable_cloud_input_mode=$enableval],
+        [enable_cloud_input_mode=no]
+)
+if test x"$enable_cloud_input_mode" = x"yes"; then
+    # check soup
+    PKG_CHECK_MODULES(LIBSOUP, [libsoup-2.4 >= 2.26])
+    AC_SUBST(LIBSOUP_CFLAGS)
+    AC_SUBST(LIBSOUP_LIBS)
+
+    # check json-glib
+    PKG_CHECK_MODULES(JSONGLIB, [json-glib-1.0 >= 1.0])
+    AC_SUBST(JSONGLIB_CFLAGS)
+    AC_SUBST(JSONGLIB_LIBS)
+fi
+AM_CONDITIONAL(ENABLE_CLOUD_INPUT_MODE, test x"$enable_cloud_input_mode" = x"yes")
+
 # --disable-english-input-mode
 AC_ARG_ENABLE(english-input-mode,
     AS_HELP_STRING([--disable-english-input-mode],
@@ -226,6 +246,7 @@ Build options:
     Use opencc                  $enable_opencc
     Use libpinyin               $enable_libpinyin
     Build lua extension         $enable_lua_extension
+    Build cloud input mode      $enable_cloud_input_mode
     Build stroke input mode     $enable_stroke_input_mode
     Build english input mode    $enable_english_input_mode
 ])

--- a/data/com.github.libpinyin.ibus-libpinyin.gschema.xml
+++ b/data/com.github.libpinyin.ibus-libpinyin.gschema.xml
@@ -209,6 +209,22 @@
       <default>0</default>
       <summary>End Timestamp for Network Dictionary</summary>
     </key>
+    <key name="enable-cloud-input" type="b">
+      <default>false</default>
+      <summary>Enable Cloud Input</summary>
+    </key>
+    <key name="cloud-input-source" type="i">
+      <default>0</default>
+      <summary>Cloud Input Source</summary>
+    </key>
+    <key name="cloud-candidates-number" type="i">
+      <default>1</default>
+      <summary>Cloud Candidates Number</summary>
+    </key>
+    <key name="cloud-request-delay-time" type="i">
+      <default>600</default>
+      <summary>Sending Cloud request with delay</summary>
+    </key>
   </schema>
   <schema path="/com/github/libpinyin/ibus-libpinyin/libbopomofo/" id="com.github.libpinyin.ibus-libpinyin.libbopomofo">
     <key name="auxiliary-select-key-f" type="i">
@@ -366,6 +382,22 @@
     <key name="network-dictionary-end-timestamp" type="x">
       <default>0</default>
       <summary>End Timestamp for Network Dictionary</summary>
+    </key>
+    <key name="enable-cloud-input" type="b">
+      <default>false</default>
+      <summary>Enable Cloud Input</summary>
+    </key>
+    <key name="cloud-input-source" type="i">
+      <default>0</default>
+      <summary>Cloud Input Source</summary>
+    </key>
+    <key name="cloud-candidates-number" type="i">
+      <default>1</default>
+      <summary>Cloud Candidates Number</summary>
+    </key>
+    <key name="cloud-request-delay-time" type="i">
+      <default>600</default>
+      <summary>Sending Cloud request with delay</summary>
     </key>
   </schema>
 </schemalist>

--- a/setup/ibus-libpinyin-preferences.ui
+++ b/setup/ibus-libpinyin-preferences.ui
@@ -133,6 +133,20 @@
       </row>
     </data>
   </object>
+  <object class="GtkListStore" id="liststoreCloudInputSource">
+    <columns>
+      <!-- column-name cloud_Input_source -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">Baidu</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Google</col>
+      </row>
+    </data>
+  </object>
   <object class="GtkDialog" id="dialog">
     <property name="width_request">400</property>
     <property name="can_focus">False</property>
@@ -1173,6 +1187,105 @@
                         <property name="expand">True</property>
                         <property name="fill">True</property>
                         <property name="position">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkFrame" id="frameCloudInput">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label_xalign">0</property>
+                        <property name="shadow_type">none</property>
+                        <child>
+                          <object class="GtkAlignment" id="alignment5">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="top_padding">6</property>
+                            <property name="left_padding">12</property>
+                            <child>
+                              <object class="GtkVBox" id="vbox17">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                  <object class="GtkCheckButton" id="InitEnableCloudInput">
+                                    <property name="label" translatable="yes">Enable Cloud Input</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="xalign">0.5</property>
+                                    <property name="draw_indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkHBox" id="hbox11">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="spacing">12</property>
+                                    <property name="homogeneous">True</property>
+                                    <child>
+                                      <object class="GtkLabel" id="label41">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="label" translatable="yes">Source From:</property>
+                                        <property name="use_markup">True</property>
+                                        <property name="xalign">0</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBox" id="CloudInputSource">
+                                        <property name="visible">True</property>
+                                        <property name="sensitive">False</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="model">liststoreCloudInputSource</property>
+                                        <property name="button_sensitivity">on</property>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="renderer7"/>
+                                          <attributes>
+                                            <attribute name="text">0</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                        <child type="label">
+                          <object class="GtkLabel" id="label36">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">&lt;b&gt;Cloud Input Option&lt;/b&gt;</property>
+                            <property name="use_markup">True</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">4</property>
                       </packing>
                     </child>
                   </object>
@@ -2326,7 +2439,7 @@ koterpilla, Zerng07, Hillwood Yang
                 </child>
               </object>
               <packing>
-                <property name="position">7</property>
+                <property name="position">8</property>
               </packing>
             </child>
             <child type="tab">
@@ -2336,7 +2449,7 @@ koterpilla, Zerng07, Hillwood Yang
                 <property name="label" translatable="yes">About</property>
               </object>
               <packing>
-                <property name="position">7</property>
+                <property name="position">8</property>
                 <property name="tab_fill">False</property>
               </packing>
             </child>

--- a/setup/main2.py
+++ b/setup/main2.py
@@ -85,6 +85,7 @@ class PreferencesDialog:
             self.__init_dictionary()
             self.__init_user_data()
             self.__init_shortcut()
+            self.__init_cloud_input()
             self.__init_about()
         elif engine == "libbopomofo":
             self.__config_namespace = "com.github.libpinyin.ibus-libpinyin.libbopomofo"
@@ -95,6 +96,7 @@ class PreferencesDialog:
             self.__init_dictionary()
             #self.__init_user_data()
             self.__init_shortcut()
+            #self.__init_cloud_input()
             self.__init_about()
             self.__convert_fuzzy_pinyin_to_bopomofo()
             self.__display_style_box.hide()
@@ -114,6 +116,7 @@ class PreferencesDialog:
         self.__page_dictionary = self.__builder.get_object("pageDictionary")
         self.__page_user_data = self.__builder.get_object("pageUserData")
         self.__page_shortcut = self.__builder.get_object("pageShortcut")
+        self.__frame_cloud_input = self.__builder.get_object("frameCloudInput")
         self.__page_about = self.__builder.get_object("pageAbout")
 
         self.__page_general.hide()
@@ -122,6 +125,7 @@ class PreferencesDialog:
         self.__page_fuzzy.hide()
         self.__page_dictionary.hide()
         self.__page_user_data.hide()
+        self.__frame_cloud_input.hide()
         self.__page_about.hide()
 
     def __init_general(self):
@@ -486,6 +490,38 @@ class PreferencesDialog:
 
     def __shortcut_changed_cb(self, editor, key, value):
         self.__set_value(key, value)
+
+    def __init_cloud_input(self):
+        # page CloudInput
+        self.__frame_cloud_input.show()
+
+        # init state
+        self.__init_enable_cloud_input = self.__builder.get_object("InitEnableCloudInput")
+
+        # cloud input option
+        self.__cloud_input_source = self.__builder.get_object("CloudInputSource")
+
+        # read values
+        self.__init_enable_cloud_input.set_active(self.__get_value("enable-cloud-input"))
+
+        self.__cloud_input_source.set_active(self.__get_value("cloud-input-source"))
+
+        if self.__init_enable_cloud_input.get_active():
+            self.__cloud_input_source.set_sensitive(True)
+        else:
+            self.__cloud_input_source.set_sensitive(False)
+
+        # connect signals
+        def __enable_cloud_input_cb(widget):
+            val = widget.get_active()
+            self.__set_value("enable-cloud-input", val)
+            self.__cloud_input_source.set_sensitive(val)
+
+        def __cloud_input_source_changed_cb(widget):
+            self.__set_value("cloud-input-source", widget.get_active())
+
+        self.__init_enable_cloud_input.connect("toggled", __enable_cloud_input_cb)
+        self.__cloud_input_source.connect("changed", __cloud_input_source_changed_cb)
 
     def __init_about(self):
         # page About

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -105,6 +105,15 @@ ibus_engine_libpinyin_c_sources += \
 	$(NULL)
 endif
 
+if ENABLE_CLOUD_INPUT_MODE
+ibus_engine_libpinyin_h_sources += \
+	PYPCloudCandidates.h \
+	$(NULL)
+ibus_engine_libpinyin_c_sources += \
+	PYPCloudCandidates.cc \
+	$(NULL)
+endif
+
 if IBUS_BUILD_STROKE_INPUT_MODE
 ibus_engine_libpinyin_c_sources += PYStrokeEditor.cc
 endif
@@ -166,6 +175,21 @@ if IBUS_BUILD_LUA_EXTENSION
 	@LUA_LIBS@ \
 	-L../lua/ \
 	-lpylua \
+	$(NULL)
+endif
+
+if ENABLE_CLOUD_INPUT_MODE
+ibus_engine_libpinyin_CXXFLAGS += \
+	@LIBSOUP_CFLAGS@ \
+	@JSONGLIB_CFLAGS@ \
+	-DENABLE_CLOUD_INPUT_MODE \
+	$(NULL)
+endif
+
+if ENABLE_CLOUD_INPUT_MODE
+ibus_engine_libpinyin_LDADD += \
+	@LIBSOUP_LIBS@ \
+	@JSONGLIB_LIBS@ \
 	$(NULL)
 endif
 

--- a/src/PYConfig.cc
+++ b/src/PYConfig.cc
@@ -72,6 +72,11 @@ Config::initDefaultValues (void)
 
     m_network_dictionary_start_timestamp = 0;
     m_network_dictionary_end_timestamp = 0;
+    
+    m_enable_cloud_input = FALSE;
+    m_cloud_candidates_number = 1;
+    m_cloud_input_source = BAIDU;
+    m_cloud_request_delay_time = 600;
 }
 
 
@@ -183,4 +188,12 @@ Config::valueChangedCallback (GSettings   *settings,
     g_variant_unref (value);
 }
 
+void 
+Config::disableCloudInput(void)
+{
+    m_enable_cloud_input = false;
+    m_cloud_candidates_number = 1;
+    m_cloud_input_source = BAIDU;
+    m_cloud_request_delay_time = 600;
+}
 };

--- a/src/PYConfig.h
+++ b/src/PYConfig.h
@@ -38,6 +38,11 @@ typedef enum {
     DISPLAY_STYLE_COMPACT
 } DisplayStyle;
 
+enum CloudInputSource{
+    BAIDU = 0,
+    GOOGLE
+};
+
 class Config {
 protected:
     Config (const std::string & name);
@@ -89,6 +94,12 @@ public:
     { return FALSE; }
     virtual gboolean networkDictionaryEndTimestamp (gint64 timestamp)
     { return FALSE; }
+    gboolean enableCloudInput (void) const      { return m_enable_cloud_input; }
+    guint cloudInputSource (void) const         { return m_cloud_input_source; }
+    guint cloudCandidatesNumber (void) const    { return m_cloud_candidates_number; }
+    guint cloudRequestDelayTime (void) const    { return m_cloud_request_delay_time; }
+    
+    void disableCloudInput(void);
 
 protected:
     bool read (const gchar * name, bool defval);
@@ -157,6 +168,10 @@ protected:
 
     gint64 m_network_dictionary_start_timestamp;
     gint64 m_network_dictionary_end_timestamp;
+    gboolean m_enable_cloud_input;
+    guint m_cloud_input_source;
+    guint m_cloud_candidates_number;
+    guint m_cloud_request_delay_time;
 };
 
 

--- a/src/PYPCloudCandidates.cc
+++ b/src/PYPCloudCandidates.cc
@@ -1,0 +1,647 @@
+/* vim:set et ts=4 sts=4:
+ *
+ * ibus-libpinyin - Intelligent Pinyin engine based on libpinyin for IBus
+ *
+ * Copyright (c) 2018 linyu Xu <liannaxu07@gmail.com>
+ * Copyright (c) 2020 Weixuan XIAO <veyx.shaw@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include "PYPCloudCandidates.h"
+#include "PYString.h"
+#include "PYConfig.h"
+#include "PYPPhoneticEditor.h"
+#include "PYPPinyinEditor.h"
+
+#include <assert.h>
+#include <pinyin.h>
+#include <cstring>
+#include <glib.h>
+
+
+using namespace PY;
+
+enum CandidateResponseParserError {
+    PARSER_NOERR,
+    PARSER_INVALID_DATA,
+    PARSER_BAD_FORMAT,
+    PARSER_NO_CANDIDATE,
+    PARSER_NETWORK_ERROR,
+    PARSER_UNKNOWN
+};
+
+static const std::string CANDIDATE_CLOUD_PREFIX = "☁";
+
+static const std::string CANDIDATE_PENDING_TEXT = CANDIDATE_CLOUD_PREFIX;
+static const std::string CANDIDATE_LOADING_TEXT = CANDIDATE_CLOUD_PREFIX + "...";
+static const std::string CANDIDATE_NO_CANDIDATE_TEXT = CANDIDATE_CLOUD_PREFIX + "[No Candidate]";
+static const std::string CANDIDATE_INVALID_DATA_TEXT = CANDIDATE_CLOUD_PREFIX + "[Invalid Data]";
+static const std::string CANDIDATE_BAD_FORMAT_TEXT = CANDIDATE_CLOUD_PREFIX + "[Bad Format]";
+
+typedef struct
+{
+    guint thread_id;
+    const gchar request_str[MAX_PINYIN_LEN + 1];
+    CloudCandidates *cloud_candidates;
+} DelayedCloudAsyncRequestCallbackUserData;
+
+class CloudCandidatesResponseParser
+{
+public:
+    CloudCandidatesResponseParser () : m_annotation (NULL) {}
+    virtual ~CloudCandidatesResponseParser () {}
+
+    virtual guint parse (GInputStream *stream) = 0;
+    virtual guint parse (const gchar *data) = 0;
+
+    virtual std::vector<std::string> &getStringCandidates () { return m_candidates; }
+    virtual std::vector<EnhancedCandidate> getCandidates ();
+    virtual const gchar *getAnnotation () { return m_annotation; }
+
+protected:
+    std::vector<std::string> m_candidates;
+    const gchar *m_annotation;
+};
+
+class CloudCandidatesResponseJsonParser : public CloudCandidatesResponseParser
+{
+public:
+    CloudCandidatesResponseJsonParser ();
+    virtual ~CloudCandidatesResponseJsonParser ();
+
+    guint parse (GInputStream *stream);
+    guint parse (const gchar *data);
+
+protected:
+    JsonParser *m_parser;
+
+    virtual guint parseJsonResponse (JsonNode *root) = 0;
+};
+
+class GoogleCloudCandidatesResponseJsonParser : public CloudCandidatesResponseJsonParser
+{
+protected:
+    guint parseJsonResponse (JsonNode *root);
+
+public:
+    GoogleCloudCandidatesResponseJsonParser () : CloudCandidatesResponseJsonParser () {}
+};
+
+class BaiduCloudCandidatesResponseJsonParser : public CloudCandidatesResponseJsonParser
+{
+private:
+    guint parseJsonResponse (JsonNode *root);
+
+public:
+    BaiduCloudCandidatesResponseJsonParser () : CloudCandidatesResponseJsonParser () {}
+    ~BaiduCloudCandidatesResponseJsonParser () { if (m_annotation) g_free ((gpointer)m_annotation); }
+};
+
+gboolean
+CloudCandidates::delayedCloudAsyncRequestCallBack (gpointer user_data)
+{
+    DelayedCloudAsyncRequestCallbackUserData *data = static_cast<DelayedCloudAsyncRequestCallbackUserData *> (user_data);
+    CloudCandidates *cloudCandidates;
+
+    if (!data)
+        return FALSE;
+
+    cloudCandidates = data->cloud_candidates;
+
+    if (!cloudCandidates)
+        return FALSE;
+
+    /* only send with a latest timer */
+    if (data->thread_id == cloudCandidates->m_source_thread_id)
+    {
+        cloudCandidates->m_source_thread_id = 0;
+        cloudCandidates->cloudAsyncRequest(data->request_str);
+    }
+
+    return FALSE;
+}
+
+void
+CloudCandidates::delayedCloudAsyncRequestDestroyCallBack (gpointer user_data)
+{
+    /* clean up */
+    if (user_data)
+        g_free (user_data);
+}
+
+CloudCandidates::CloudCandidates (PhoneticEditor * editor)
+{
+    m_session = soup_session_new ();
+    m_editor = editor;
+
+    m_cloud_source = m_editor->m_config.cloudInputSource ();
+    m_cloud_flag = FALSE;
+    m_delayed_time = m_editor->m_config.cloudRequestDelayTime ();
+    m_cloud_candidates_number = m_editor->m_config.cloudCandidatesNumber ();
+
+    m_source_thread_id = 0;
+    m_message = NULL;
+}
+
+CloudCandidates::~CloudCandidates ()
+{
+}
+
+gboolean
+CloudCandidates::processCandidates (std::vector<EnhancedCandidate> & candidates)
+{
+    /* refer pinyin retrieved in full pinyin mode */
+    const gchar *full_pinyin_text;
+
+    /* refer pinyin generated in double pinyin mode, need free */
+    gchar *double_pinyin_text;
+
+    /* check the length of the first n-gram candidate */
+    std::vector<EnhancedCandidate>::iterator n_gram_sentence_candidate = candidates.begin ();
+    if (n_gram_sentence_candidate == candidates.end ())
+    {
+        m_cloud_candidates_first_pos = candidates.end ();
+        return FALSE;   /* no candidate */
+    }
+    if (g_utf8_strlen (n_gram_sentence_candidate->m_display_string.c_str(), -1) < CLOUD_MINIMUM_UTF8_TRIGGER_LENGTH)
+    {
+        m_cloud_candidates_first_pos = candidates.end ();
+        return FALSE;   /* do not request because there is only one character */
+    }
+
+    /* check pinyin length */
+    if (! m_editor->m_config.doublePinyin ())
+        full_pinyin_text = m_editor->m_text;
+    else
+    {
+        m_editor->updateAuxiliaryText ();
+        String stripped = m_editor->m_buffer;
+        const gchar *temp= stripped;
+        gchar** tempArray =  g_strsplit_set (temp, " |", -1);
+        double_pinyin_text = g_strjoinv ("", tempArray);
+
+        g_strfreev (tempArray);
+    }
+
+    /* search the first non-ngram candidate */
+    for (m_cloud_candidates_first_pos = candidates.begin (); m_cloud_candidates_first_pos != candidates.end (); ++m_cloud_candidates_first_pos) {
+        if (CANDIDATE_NBEST_MATCH != m_cloud_candidates_first_pos->m_candidate_type)
+            break;
+    }
+
+    /* have cloud candidates already */
+    EnhancedCandidate testCan = *m_cloud_candidates_first_pos;
+    if (testCan.m_candidate_type == CANDIDATE_CLOUD_INPUT)
+        return FALSE;
+
+    /* insert cloud candidates' placeholders */
+    m_candidates.clear ();
+    for (guint i = 0; i < m_cloud_candidates_number; ++i) {
+        EnhancedCandidate enhanced;
+        enhanced.m_display_string = CANDIDATE_PENDING_TEXT;
+        enhanced.m_candidate_type = CANDIDATE_CLOUD_INPUT;
+        m_candidates.push_back (enhanced);
+    }
+    candidates.insert (m_cloud_candidates_first_pos, m_candidates.begin (), m_candidates.end ());
+
+    /* note the last cloud input candidate position */
+    m_candidates_end_pos = m_cloud_candidates_first_pos + m_cloud_candidates_number;
+
+    if (! m_editor->m_config.doublePinyin ()) {
+        delayedCloudAsyncRequest (full_pinyin_text);
+    } else {
+        delayedCloudAsyncRequest (double_pinyin_text);
+        g_free (double_pinyin_text);
+    }
+
+    return TRUE;
+}
+
+int
+CloudCandidates::selectCandidate (EnhancedCandidate & enhanced)
+{
+    assert (CANDIDATE_CLOUD_INPUT == enhanced.m_candidate_type);
+
+    if (enhanced.m_display_string == CANDIDATE_PENDING_TEXT ||
+        enhanced.m_display_string == CANDIDATE_LOADING_TEXT ||
+        enhanced.m_display_string == CANDIDATE_BAD_FORMAT_TEXT ||
+        enhanced.m_display_string == CANDIDATE_INVALID_DATA_TEXT)
+        return SELECT_CANDIDATE_ALREADY_HANDLED;
+
+    /* take the cached candidate with the same candidate id */
+    for (std::vector<EnhancedCandidate>::iterator pos = m_candidates.begin(); pos != m_candidates.end(); ++pos) {
+        if (pos->m_candidate_id == enhanced.m_candidate_id) {
+            enhanced.m_display_string = pos->m_display_string;
+            return SELECT_CANDIDATE_COMMIT;
+        }
+    }
+
+    return SELECT_CANDIDATE_ALREADY_HANDLED;
+}
+
+void
+CloudCandidates::delayedCloudAsyncRequest (const gchar* requestStr)
+{
+    gpointer user_data;
+    DelayedCloudAsyncRequestCallbackUserData *data;
+    guint thread_id;
+
+    /* cancel the latest timer, if applied */
+    if (m_source_thread_id != 0)
+        g_source_remove(m_source_thread_id);
+
+    /* allocate memory for a DelayedCloudAsyncRequestCallbackUserData instance to take more callback user data */
+    user_data = g_malloc (sizeof(DelayedCloudAsyncRequestCallbackUserData));
+    data = static_cast<DelayedCloudAsyncRequestCallbackUserData *> (user_data);
+
+    strcpy((char *)(data->request_str), (const char *)requestStr);
+    data->cloud_candidates = this;
+
+    /* record the latest timer */
+    thread_id = m_source_thread_id = g_timeout_add_full(G_PRIORITY_DEFAULT, m_delayed_time, delayedCloudAsyncRequestCallBack, user_data, delayedCloudAsyncRequestDestroyCallBack);
+    data->thread_id = thread_id;
+}
+
+void
+CloudCandidates::cloudAsyncRequest (const gchar* requestStr, std::vector<EnhancedCandidate> & candidates)
+{
+    cloudAsyncRequest(requestStr);
+}
+
+void
+CloudCandidates::cloudAsyncRequest (const gchar* requestStr)
+{
+    GError **error = NULL;
+    gchar *queryRequest;
+    if (m_cloud_source == BAIDU)
+        queryRequest= g_strdup_printf ("http://olime.baidu.com/py?input=%s&inputtype=py&bg=0&ed=%d&result=hanzi&resultcoding=utf-8&ch_en=1&clientinfo=web&version=1", requestStr, m_cloud_candidates_number);
+    else if (m_cloud_source == GOOGLE)
+        queryRequest= g_strdup_printf ("https://www.google.com/inputtools/request?ime=pinyin&text=%s&num=%d", requestStr, m_cloud_candidates_number);
+
+    /* cancel message if there is a pending one */
+    if (m_message)
+        soup_session_cancel_message (m_session, m_message, SOUP_STATUS_CANCELLED);
+
+    SoupMessage *msg = soup_message_new ("GET", queryRequest);
+    soup_session_send_async (m_session, msg, NULL, cloudResponseCallBack, static_cast<gpointer> (this));
+    m_message = msg;
+
+    /* update loading text to replace pending text */
+    for (std::vector<EnhancedCandidate>::iterator pos = m_cloud_candidates_first_pos; pos != m_candidates_end_pos; ++pos) {
+        if (CANDIDATE_CLOUD_INPUT == pos->m_candidate_type) {
+            if (CANDIDATE_PENDING_TEXT == pos->m_display_string) {
+                pos->m_display_string = CANDIDATE_LOADING_TEXT;
+            }
+        } else
+            break;
+    }
+
+    /* only update lookup table when there is still pinyin text */
+    if (strlen (m_editor->m_text) >= CLOUD_MINIMUM_TRIGGER_LENGTH)
+        updateLookupTable ();
+}
+
+void
+CloudCandidates::cloudResponseCallBack (GObject *source_object, GAsyncResult *result, gpointer user_data)
+{
+    GError **error = NULL;
+    GInputStream *stream = soup_session_send_finish (SOUP_SESSION (source_object), result, error);
+    CloudCandidates *cloudCandidates = static_cast<CloudCandidates *> (user_data);
+
+    /* process results */
+    cloudCandidates->processCloudResponse (stream, cloudCandidates->m_editor->m_candidates);
+
+    /* only update lookup table when there is still pinyin text */
+    if (strlen (cloudCandidates->m_editor->m_text) >= CLOUD_MINIMUM_TRIGGER_LENGTH)
+    {
+        cloudCandidates->updateLookupTable ();
+
+        /* clean up message */
+        cloudCandidates->m_message = NULL;
+    }
+}
+
+void
+CloudCandidates::cloudSyncRequest (const gchar* requestStr, std::vector<EnhancedCandidate> & candidates)
+{
+    GError **error = NULL;
+    gchar *queryRequest;
+    if (m_cloud_source == BAIDU)
+        queryRequest= g_strdup_printf ("http://olime.baidu.com/py?input=%s&inputtype=py&bg=0&ed=%d&result=hanzi&resultcoding=utf-8&ch_en=1&clientinfo=web&version=1", requestStr, m_cloud_candidates_number);
+    else if (m_cloud_source == GOOGLE)
+        queryRequest= g_strdup_printf ("https://www.google.com/inputtools/request?ime=pinyin&text=%s&num=%d", requestStr, m_cloud_candidates_number);
+    SoupMessage *msg = soup_message_new ("GET", queryRequest);
+
+    GInputStream *stream = soup_session_send (m_session, msg, NULL, error);
+
+    processCloudResponse (stream, candidates);
+}
+
+void
+CloudCandidates::processCloudResponse (GInputStream *stream, std::vector<EnhancedCandidate> & candidates)
+{
+    guint ret_code;
+    CloudCandidatesResponseJsonParser *parser = NULL;
+    const gchar *text = NULL;
+    gchar *double_pinyin_text = NULL;
+    gchar annotation[MAX_PINYIN_LEN + 1];
+
+    if (m_cloud_source == BAIDU)
+        parser = new BaiduCloudCandidatesResponseJsonParser ();
+    else if (m_cloud_source == GOOGLE)
+        parser = new GoogleCloudCandidatesResponseJsonParser ();
+
+    ret_code = parser->parse (stream);
+
+    if (parser->getAnnotation ())
+        strcpy (annotation, parser->getAnnotation ());
+    else
+    {
+        /* the request might have been cancelled */
+        return;
+    }
+
+    if (! m_editor->m_config.doublePinyin ())
+    {
+        /* get current text in editor */
+        text = m_editor->m_text;
+    }
+    else
+    {
+        /* get current double pinyin text */
+        String stripped = m_editor->m_buffer;
+        const gchar *temp= stripped;
+        gchar** tempArray =  g_strsplit_set (temp, " |", -1);
+        double_pinyin_text = g_strjoinv ("", tempArray);
+        g_strfreev (tempArray);
+    }
+
+    if (ret_code == PARSER_NETWORK_ERROR)
+    {
+        for (std::vector<EnhancedCandidate>::iterator pos = m_cloud_candidates_first_pos; pos != m_candidates_end_pos; ++pos) {
+            if (CANDIDATE_CLOUD_INPUT == pos->m_candidate_type) {
+                pos->m_display_string = CANDIDATE_INVALID_DATA_TEXT;
+            } else
+                break;
+        }
+    }
+    else if (m_cloud_source == BAIDU || !g_strcmp0 (annotation, text) || !g_strcmp0 (annotation, double_pinyin_text))
+    {
+        if (ret_code == PARSER_NOERR)
+        {
+            /* update to the candidates list */
+            std::vector<std::string> &updated_candidates = parser->getStringCandidates ();
+
+            std::vector<EnhancedCandidate>::iterator pos = m_cloud_candidates_first_pos;
+            std::vector<EnhancedCandidate>::iterator cached_candidate_pos = m_candidates.begin();
+            for (guint i = 0; cached_candidate_pos != m_candidates.end() && pos != m_candidates_end_pos && i < updated_candidates.size ();
+                ++i, ++pos, ++cached_candidate_pos)
+            {
+                /* display candidate with prefix in lookup table */
+                EnhancedCandidate & enhanced = *pos;
+                enhanced.m_candidate_id = i;
+                enhanced.m_display_string = CANDIDATE_CLOUD_PREFIX + updated_candidates[i];
+
+                /* cache candidate without prefix in m_candidates */
+                EnhancedCandidate & cached = *cached_candidate_pos;
+                cached.m_display_string = updated_candidates[i];
+                cached.m_candidate_id = enhanced.m_candidate_id;
+            }
+        }
+        else if (ret_code == PARSER_NO_CANDIDATE)
+        {
+            for (std::vector<EnhancedCandidate>::iterator pos = m_cloud_candidates_first_pos; pos != m_candidates_end_pos; ++pos) {
+                if (CANDIDATE_CLOUD_INPUT == pos->m_candidate_type) {
+                    pos->m_display_string = CANDIDATE_NO_CANDIDATE_TEXT;
+                } else
+                    break;
+            }
+        }
+        else if (ret_code == PARSER_INVALID_DATA)
+        {
+             for (std::vector<EnhancedCandidate>::iterator pos = m_cloud_candidates_first_pos; pos != m_candidates_end_pos; ++pos) {
+                if (CANDIDATE_CLOUD_INPUT == pos->m_candidate_type) {
+                    pos->m_display_string = CANDIDATE_INVALID_DATA_TEXT;
+                } else
+                    break;
+            }
+        }
+        else if (ret_code == PARSER_BAD_FORMAT)
+        {
+            for (std::vector<EnhancedCandidate>::iterator pos = m_cloud_candidates_first_pos; pos != m_candidates_end_pos; ++pos) {
+                if (CANDIDATE_CLOUD_INPUT == pos->m_candidate_type) {
+                    pos->m_display_string = CANDIDATE_BAD_FORMAT_TEXT;
+                } else
+                    break;
+            }
+        }
+    }
+
+    if (parser)
+        delete parser;
+
+    if (double_pinyin_text)
+        g_free (double_pinyin_text);
+}
+
+void
+CloudCandidates::updateLookupTable ()
+{
+    /* retrieve cursor position in lookup table */
+    guint cursor = m_editor->m_lookup_table.cursorPos ();
+
+    /* regenerate lookup table */
+    m_editor->m_lookup_table.clear ();
+    m_editor->fillLookupTable ();
+
+    /* recover cursor position in lookup table */
+    m_editor->m_lookup_table.setCursorPos (cursor);
+
+    /* notify ibus */
+    m_editor->updateLookupTableFast ();
+}
+
+std::vector<EnhancedCandidate> CloudCandidatesResponseParser::getCandidates ()
+{
+    std::vector<EnhancedCandidate> candidates;
+
+    for (std::vector<std::string>::const_iterator i = m_candidates.cbegin (); i != m_candidates.cend (); ++i)
+    {
+        EnhancedCandidate candidate;
+        candidate.m_candidate_type = CANDIDATE_CLOUD_INPUT;
+        candidate.m_display_string = *i;
+        candidates.push_back (candidate);
+    }
+
+    return candidates;
+}
+
+CloudCandidatesResponseJsonParser::CloudCandidatesResponseJsonParser () : m_parser (NULL)
+{
+    m_parser = json_parser_new ();
+}
+
+CloudCandidatesResponseJsonParser::~CloudCandidatesResponseJsonParser ()
+{
+    /* free json parser object if necessary */
+    if (m_parser)
+        g_object_unref (m_parser);
+}
+
+guint CloudCandidatesResponseJsonParser::parse (GInputStream *stream)
+{
+    GError **error = NULL;
+
+    if (!stream)
+        return PARSER_NETWORK_ERROR;
+
+    /* parse Json from input steam */
+    if (!json_parser_load_from_stream (m_parser, stream, NULL, error) || error != NULL)
+    {
+        g_input_stream_close (stream, NULL, error);  /* Close stream to release libsoup connexion */
+        return PARSER_BAD_FORMAT;
+    }
+    g_input_stream_close (stream, NULL, error);  /* Close stream to release libsoup connexion */
+
+    return parseJsonResponse (json_parser_get_root (m_parser));
+}
+
+guint CloudCandidatesResponseJsonParser::parse (const gchar *data)
+{
+    GError **error = NULL;
+
+    if (!data)
+        return PARSER_NETWORK_ERROR;
+
+    /* parse Json from data */
+    if (!json_parser_load_from_data (m_parser, data, strlen (data), error) || error != NULL)
+        return PARSER_BAD_FORMAT;
+
+    return parseJsonResponse (json_parser_get_root (m_parser));
+}
+
+guint GoogleCloudCandidatesResponseJsonParser::parseJsonResponse (JsonNode *root)
+{
+    if (!JSON_NODE_HOLDS_ARRAY (root))
+        return PARSER_BAD_FORMAT;
+
+    /* validate Google source and the structure of response */
+    JsonArray *google_root_array = json_node_get_array (root);
+
+    const gchar *google_response_status;
+    JsonArray *google_response_array;
+    JsonArray *google_result_array;
+    const gchar *google_candidate_annotation;
+    JsonArray *google_candidate_array;
+    guint result_counter;
+
+    if (json_array_get_length (google_root_array) <= 1)
+        return PARSER_INVALID_DATA;
+
+    google_response_status = json_array_get_string_element (google_root_array, 0);
+
+    if (g_strcmp0 (google_response_status, "SUCCESS"))
+        return PARSER_INVALID_DATA;
+
+    google_response_array = json_array_get_array_element (google_root_array, 1);
+
+    if (json_array_get_length (google_response_array) < 1)
+        return PARSER_INVALID_DATA;
+
+    google_result_array = json_array_get_array_element (google_response_array, 0);
+
+    google_candidate_annotation = json_array_get_string_element (google_result_array, 0);
+
+    if (!google_candidate_annotation)
+        return PARSER_INVALID_DATA;
+
+    /* update annotation with the returned annotation */
+    m_annotation = google_candidate_annotation;
+
+    google_candidate_array = json_array_get_array_element (google_result_array, 1);
+
+    result_counter = json_array_get_length (google_candidate_array);
+
+    if (result_counter < 1)
+        return PARSER_NO_CANDIDATE;
+
+    for (guint i = 0; i < result_counter; ++i)
+    {
+        std::string candidate = json_array_get_string_element (google_candidate_array, i);
+        m_candidates.push_back (candidate);
+    }
+
+    return PARSER_NOERR;
+}
+
+guint BaiduCloudCandidatesResponseJsonParser::parseJsonResponse (JsonNode *root)
+{
+    if (!JSON_NODE_HOLDS_OBJECT (root))
+        return PARSER_BAD_FORMAT;
+
+    /* validate Baidu source and the structure of response */
+    JsonObject *baidu_root_object = json_node_get_object (root);
+    const gchar *baidu_response_status;
+    JsonArray *baidu_result_array;
+    JsonArray *baidu_candidate_array;
+    const gchar *baidu_candidate_annotation;
+    guint result_counter;
+
+    if (!json_object_has_member (baidu_root_object, "status"))
+        return PARSER_INVALID_DATA;
+
+    baidu_response_status = json_object_get_string_member (baidu_root_object, "status");
+
+    if (g_strcmp0 (baidu_response_status, "T"))
+        return PARSER_INVALID_DATA;
+
+    if (!json_object_has_member (baidu_root_object, "result"))
+        return PARSER_INVALID_DATA;
+
+    baidu_result_array = json_object_get_array_member (baidu_root_object, "result");
+
+    baidu_candidate_array = json_array_get_array_element (baidu_result_array, 0);
+    baidu_candidate_annotation = json_array_get_string_element (baidu_result_array, 1);
+
+    if (!baidu_candidate_annotation)
+        return PARSER_INVALID_DATA;
+
+    /* update annotation with the returned annotation */
+    m_annotation = NULL;
+    gchar **words = g_strsplit (baidu_candidate_annotation, "'", -1);
+    m_annotation = g_strjoinv ("", words);
+    g_strfreev (words);
+
+    result_counter = json_array_get_length (baidu_candidate_array);
+
+    if (result_counter < 1)
+        return PARSER_NO_CANDIDATE;
+
+    for (guint i = 0; i < result_counter; ++i)
+    {
+        std::string candidate;
+        JsonArray *baidu_candidate = json_array_get_array_element (baidu_candidate_array, i);
+
+        if (json_array_get_length (baidu_candidate) < 1)
+            candidate = CANDIDATE_INVALID_DATA_TEXT;
+        else
+            candidate = json_array_get_string_element (baidu_candidate, 0);
+
+        m_candidates.push_back (candidate);
+    }
+
+    return PARSER_NOERR;
+}

--- a/src/PYPCloudCandidates.h
+++ b/src/PYPCloudCandidates.h
@@ -1,0 +1,90 @@
+/* vim:set et ts=4 sts=4:
+ *
+ * ibus-libpinyin - Intelligent Pinyin engine based on libpinyin for IBus
+ *
+ * Copyright (c) 2018 linyu Xu <liannaxu07@gmail.com>
+ * Copyright (c) 2020 Weixuan XIAO <veyx.shaw@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef __PY_LIB_PINYIN_ClOUD_CANDIDATES_H_
+#define __PY_LIB_PINYIN_ClOUD_CANDIDATES_H_
+
+#include "PYString.h"
+#include "PYPointer.h"
+#include "PYPEnhancedCandidates.h"
+#include <vector>
+#include <libsoup/soup.h>
+#include <json-glib/json-glib.h>
+#include "PYConfig.h"
+
+
+
+namespace PY {
+    
+#define BUFFERLENGTH 2048
+#define CLOUD_MINIMUM_TRIGGER_LENGTH 2
+#define CLOUD_MINIMUM_UTF8_TRIGGER_LENGTH 2
+
+class PhoneticEditor;
+
+class CloudCandidates : public EnhancedCandidates<PhoneticEditor> 
+{
+public:
+
+    CloudCandidates (PhoneticEditor *editor);
+    ~CloudCandidates();
+    
+    gboolean processCandidates (std::vector<EnhancedCandidate> & candidates);
+    
+    int selectCandidate (EnhancedCandidate & enhanced);
+    
+    void cloudAsyncRequest (const gchar* requestStr);
+    void cloudAsyncRequest (const gchar* requestStr, std::vector<EnhancedCandidate> & candidates);
+    void cloudSyncRequest (const gchar* requestStr, std::vector<EnhancedCandidate> & candidates);
+
+    void delayedCloudAsyncRequest (const gchar* requestStr);
+
+    void updateLookupTable ();
+
+    guint m_cloud_source;
+    guint m_cloud_candidates_number;
+    guint m_min_cloud_trigger_length;
+    gboolean m_cloud_flag;
+    guint m_delayed_time;
+    guint m_source_thread_id;
+    SoupMessage *m_message;
+    std::vector<EnhancedCandidate>::iterator m_cloud_candidates_first_pos;
+    std::vector<EnhancedCandidate>::iterator m_candidates_end_pos;
+    
+private:
+    static gboolean delayedCloudAsyncRequestCallBack (gpointer user_data);
+    static void delayedCloudAsyncRequestDestroyCallBack (gpointer user_data);
+    static void cloudResponseCallBack (GObject *object, GAsyncResult *result, gpointer user_data);
+
+    void processCloudResponse (GInputStream *stream, std::vector<EnhancedCandidate> & candidates);
+private:
+    SoupSession *m_session;
+    
+protected:
+    std::vector<EnhancedCandidate> m_candidates;
+};
+
+};
+
+#endif
+
+

--- a/src/PYPConfig.cc
+++ b/src/PYPConfig.cc
@@ -67,6 +67,10 @@ const gchar * const CONFIG_BOTH_SWITCH               = "both-switch";
 const gchar * const CONFIG_TRAD_SWITCH               = "trad-switch";
 const gchar * const CONFIG_NETWORK_DICTIONARY_START_TIMESTAMP = "network-dictionary-start-timestamp";
 const gchar * const CONFIG_NETWORK_DICTIONARY_END_TIMESTAMP   = "network-dictionary-end-timestamp";
+const gchar * const CONFIG_INIT_ENABLE_CLOUD_INPUT   = "enable-cloud-input";
+const gchar * const CONFIG_CLOUD_INPUT_SOURCE        = "cloud-input-source";   
+const gchar * const CONFIG_CLOUD_CANDIDATES_NUMBER   = "cloud-candidates-number";
+const gchar * const CONFIG_CLOUD_REQUEST_DELAY_TIME  = "cloud-request-delay-time";
 
 const pinyin_option_t PINYIN_DEFAULT_OPTION =
         PINYIN_INCOMPLETE |
@@ -149,6 +153,10 @@ LibPinyinConfig::initDefaultValues (void)
 
     m_network_dictionary_start_timestamp = 0;
     m_network_dictionary_end_timestamp = 0;
+    m_enable_cloud_input = FALSE;
+    m_cloud_candidates_number = 1;
+    m_cloud_input_source = BAIDU;
+    m_cloud_request_delay_time = 600;
 }
 
 static const struct {
@@ -282,6 +290,8 @@ LibPinyinConfig::readDefaultValues (void)
             m_option &= ~options[i].option;
         }
     }
+    
+    m_enable_cloud_input = read (CONFIG_INIT_ENABLE_CLOUD_INPUT, false);
 #endif
 }
 
@@ -351,6 +361,10 @@ LibPinyinConfig::valueChanged (const std::string &schema_id,
         m_network_dictionary_start_timestamp = normalizeGVariant (value, (gint64) 0);
     } else if (CONFIG_NETWORK_DICTIONARY_END_TIMESTAMP == name) {
         m_network_dictionary_end_timestamp = normalizeGVariant (value, (gint64) 0);
+    }
+    /*cloud input*/
+    else if (CONFIG_INIT_ENABLE_CLOUD_INPUT == name) {
+        m_enable_cloud_input = normalizeGVariant (value, false);
     }
     /* fuzzy pinyin */
     else if (CONFIG_FUZZY_PINYIN == name) {
@@ -488,6 +502,22 @@ PinyinConfig::readDefaultValues (void)
         else
             m_option &= ~pinyin_options[i].option;
     }
+    m_cloud_candidates_number = read (CONFIG_CLOUD_CANDIDATES_NUMBER, 1);
+    if (m_cloud_candidates_number > 10 || m_cloud_candidates_number < 1) {
+        m_cloud_candidates_number = 1;
+        g_warn_if_reached ();
+    }
+    m_cloud_input_source = read (CONFIG_CLOUD_INPUT_SOURCE, 0);
+    if (m_cloud_input_source != BAIDU &&
+        m_cloud_input_source != GOOGLE) {
+        m_cloud_input_source = BAIDU;
+        g_warn_if_reached ();
+    }
+    m_cloud_request_delay_time = read (CONFIG_CLOUD_REQUEST_DELAY_TIME, 600);
+    if (m_cloud_request_delay_time > 2000 || m_cloud_request_delay_time < 200) {
+        m_cloud_request_delay_time = 600;
+        g_warn_if_reached ();
+    }
 #endif
 }
 
@@ -554,6 +584,28 @@ PinyinConfig::valueChanged (const std::string &schema_id,
         else
             m_option_mask &= ~PINYIN_CORRECT_ALL;
     }
+    else if (CONFIG_CLOUD_CANDIDATES_NUMBER == name) {
+        m_cloud_candidates_number = normalizeGVariant (value, 1);
+        if (m_cloud_candidates_number > 10 || m_cloud_candidates_number < 1) {
+            m_cloud_candidates_number = 1;
+            g_warn_if_reached ();
+        }
+    }
+    else if (CONFIG_CLOUD_INPUT_SOURCE == name) {
+        m_cloud_input_source = normalizeGVariant (value, BAIDU);
+        if (m_cloud_input_source != BAIDU &&
+            m_cloud_input_source != GOOGLE) {
+            m_cloud_input_source = BAIDU;
+            g_warn_if_reached ();
+        }
+    }
+    else if (CONFIG_CLOUD_REQUEST_DELAY_TIME == name) {
+        m_cloud_request_delay_time = read (CONFIG_CLOUD_REQUEST_DELAY_TIME, 600);
+        if (m_cloud_request_delay_time > 2000 || m_cloud_request_delay_time < 200) {
+            m_cloud_request_delay_time = 600;
+            g_warn_if_reached ();
+        }
+    }
     else {
         for (guint i = 0; i < G_N_ELEMENTS (pinyin_options); i++) {
             if (G_LIKELY (pinyin_options[i].name != name))
@@ -593,6 +645,8 @@ BopomofoConfig::init ()
         m_instance.reset (new BopomofoConfig ());
         m_instance->readDefaultValues ();
     }
+    /*disable cloud input by default*/
+    m_instance->disableCloudInput();
 }
 
 void

--- a/src/PYPPhoneticEditor.cc
+++ b/src/PYPPhoneticEditor.cc
@@ -37,6 +37,9 @@ PhoneticEditor::PhoneticEditor (PinyinProperties &props,
     m_lua_converter_candidates (this),
 #endif
     m_emoji_candidates (this),
+#ifdef ENABLE_CLOUD_INPUT_MODE
+    m_cloud_candidates(this),
+#endif
     m_traditional_candidates (this, config)
 {
 }
@@ -239,6 +242,12 @@ PhoneticEditor::updateCandidates (void)
     }
 #endif
 
+#ifdef ENABLE_CLOUD_INPUT_MODE
+    /* keep me behind the other kinds of candidates which are inserted after n-gram candidates */
+    if(m_config.enableCloudInput ())
+        m_cloud_candidates.processCandidates (m_candidates);
+#endif
+
     if (!m_props.modeSimp ())
         m_traditional_candidates.processCandidates (m_candidates);
 
@@ -367,6 +376,11 @@ PhoneticEditor::selectCandidateInternal (EnhancedCandidate & candidate)
     case CANDIDATE_TRADITIONAL_CHINESE:
         return m_traditional_candidates.selectCandidate (candidate);
 
+#ifdef ENABLE_CLOUD_INPUT_MODE
+    case CANDIDATE_CLOUD_INPUT:
+        return m_cloud_candidates.selectCandidate (candidate);
+#endif
+        
 #ifdef IBUS_BUILD_LUA_EXTENSION
     case CANDIDATE_LUA_TRIGGER:
         return m_lua_trigger_candidates.selectCandidate (candidate);

--- a/src/PYPPhoneticEditor.h
+++ b/src/PYPPhoneticEditor.h
@@ -39,10 +39,15 @@
 
 #include "PYPEmojiCandidates.h"
 
+#ifdef ENABLE_CLOUD_INPUT_MODE
+#include "PYPCloudCandidates.h"
+#endif
+
 namespace PY {
 
 class PhoneticEditor : public Editor {
     friend class LibPinyinCandidates;
+    friend class CloudCandidates;
 
 public:
     PhoneticEditor (PinyinProperties & props, Config & config);
@@ -125,6 +130,10 @@ protected:
     EmojiCandidates m_emoji_candidates;
 
     TraditionalCandidates m_traditional_candidates;
+    
+#ifdef ENABLE_CLOUD_INPUT_MODE
+    CloudCandidates m_cloud_candidates;
+#endif
 };
 
 };


### PR DESCRIPTION
Improve Cloud Input feature based on the previous work:
- utilize `json-glib` to parse the result and validate the format;
- by default, send an asynchronous request via `libsoup`;
- sending request will be delayed with a given time (various between 0.2s and 2.0s, can be customized by user in setup page);
- a new request will be sent after cancelling the previous request, if the previous one is not completed;
- in the lookup table, the cloud candidate(s) will indicate some different steps: CANDIDATE_PENDING_TEXT(request has not yet been sent) -> CANDIDATE_LOADING_TEXT(request sent, not yet response) ->
candidate(s) from Cloud Input source/error information.