### PR TITLE
support `require` in user.lua

### DIFF
--- a/lua/lua-plugin-init.c
+++ b/lua/lua-plugin-init.c
@@ -37,6 +37,7 @@
 
 static const luaL_Reg lualibs[] = {
   {"", luaopen_base},
+  {LUA_LOADLIBNAME, luaopen_package},
   {LUA_TABLIBNAME, luaopen_table},
   {LUA_IOLIBNAME, luaopen_io},
   {LUA_OSLIBNAME, luaopen_myos},
@@ -48,17 +49,6 @@ static const luaL_Reg lualibs[] = {
 
 
 void lua_plugin_openlibs (lua_State *L) {
-  luaL_openlibs(L); // alllow `require`
-  gchar * user_dir = g_build_filename (g_get_user_config_dir (),
-                                        "ibus", "libpinyin", NULL);
-  lua_getglobal(L, "package");
-  lua_pushfstring(L, "%s%slua%s?.lua;", user_dir, LUA_DIRSEP, LUA_DIRSEP);
-  lua_getfield(L, -2, "path");
-  lua_concat(L, 2);
-  lua_setfield(L, -2, "path");
-  lua_pop(L, 1);
-  g_free(user_dir); // add `~/,config/ibus/libpinyin/lua` to path
-
   const luaL_Reg *lib = lualibs;
   for (; lib->func; lib++) {
 #if LUA_VERSION_NUM >= 502
@@ -69,6 +59,17 @@ void lua_plugin_openlibs (lua_State *L) {
     lua_call(L, 1, 0);
 #endif
   }
+
+  // add `~/.config/ibus/libpinyin/lua` to lua load path
+  gchar * user_dir = g_build_filename (g_get_user_config_dir (),
+                                        "ibus", "libpinyin", NULL);
+  lua_getglobal(L, "package");
+  lua_pushfstring(L, "%s%slua%s?.lua;", user_dir, LUA_DIRSEP, LUA_DIRSEP);
+  lua_getfield(L, -2, "path");
+  lua_concat(L, 2);
+  lua_setfield(L, -2, "path");
+  lua_pop(L, 1);
+  g_free(user_dir);
 }
 
 void lua_plugin_store_plugin(lua_State * L, IBusEnginePlugin * plugin){

--- a/lua/lua-plugin-init.c
+++ b/lua/lua-plugin-init.c
@@ -48,6 +48,17 @@ static const luaL_Reg lualibs[] = {
 
 
 void lua_plugin_openlibs (lua_State *L) {
+  luaL_openlibs(L); // alllow `require`
+  gchar * user_dir = g_build_filename (g_get_user_config_dir (),
+                                        "ibus", "libpinyin", NULL);
+  lua_getglobal(L, "package");
+  lua_pushfstring(L, "%s%slua%s?.lua;", user_dir, LUA_DIRSEP, LUA_DIRSEP);
+  lua_getfield(L, -2, "path");
+  lua_concat(L, 2);
+  lua_setfield(L, -2, "path");
+  lua_pop(L, 1);
+  g_free(user_dir); // add `~/,config/ibus/libpinyin/lua` to path
+
   const luaL_Reg *lib = lualibs;
   for (; lib->func; lib++) {
 #if LUA_VERSION_NUM >= 502


### PR DESCRIPTION
我对 c 怎么和 lua 交互并不熟悉，参考了 [librime-lua](https://github.com/hchunhui/librime-lua/blob/master/src/modules.cc#L13) 和这篇[博客](https://blog.csdn.net/qq479664290/article/details/52996119)依样画葫芦。
```lua
-- ~/.config/ibus/libpinyin/user.lua
test = require("tests")
ime.register_trigger('test', 'desc', {'ts'}, {'一', '甲', '🦐'})
```
```lua
-- ~/.config/ibus/libpinyin/lua/tests.lua
local function test()
    return 'tot'
end

return test
```
终端:
![image](https://user-images.githubusercontent.com/17917040/88243440-fe46dc80-ccc2-11ea-89e7-912790890088.png)
实际:
![libpinyin](https://user-images.githubusercontent.com/17917040/88243581-672e5480-ccc3-11ea-8fad-b24204964c36.gif)
