### PR TITLE
Add Cloud Input feature into ibus-libpinyin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -181,6 +181,26 @@ fi
 
 AM_CONDITIONAL(IBUS_BUILD_LUA_EXTENSION, [test x"$enable_lua_extension" = x"yes"])
 
+# --enable-cloud-input-mode
+AC_ARG_ENABLE(cloud-input-mode,
+    AC_HELP_STRING([--enable-cloud-input-mode],
+        [add cloud candidates]),
+        [enable_cloud_input_mode=$enableval],
+        [enable_cloud_input_mode=no]
+)
+if test x"$enable_cloud_input_mode" = x"yes"; then
+    # check soup
+    PKG_CHECK_MODULES(LIBSOUP, [libsoup-2.4 >= 2.26])
+    AC_SUBST(LIBSOUP_CFLAGS)
+    AC_SUBST(LIBSOUP_LIBS)
+
+    # check json-glib
+    PKG_CHECK_MODULES(JSONGLIB, [json-glib-1.0 >= 1.0])
+    AC_SUBST(JSONGLIB_CFLAGS)
+    AC_SUBST(JSONGLIB_LIBS)
+fi
+AM_CONDITIONAL(ENABLE_CLOUD_INPUT_MODE, test x"$enable_cloud_input_mode" = x"yes")
+
 # --disable-english-input-mode
 AC_ARG_ENABLE(english-input-mode,
     AS_HELP_STRING([--disable-english-input-mode],
@@ -226,6 +246,7 @@ Build options:
     Use opencc                  $enable_opencc
     Use libpinyin               $enable_libpinyin
     Build lua extension         $enable_lua_extension
+    Build cloud input mode      $enable_cloud_input_mode
     Build stroke input mode     $enable_stroke_input_mode
     Build english input mode    $enable_english_input_mode
 ])

--- a/data/com.github.libpinyin.ibus-libpinyin.gschema.xml
+++ b/data/com.github.libpinyin.ibus-libpinyin.gschema.xml
@@ -209,6 +209,22 @@
       <default>0</default>
       <summary>End Timestamp for Network Dictionary</summary>
     </key>
+    <key name="enable-cloud-input" type="b">
+      <default>false</default>
+      <summary>Enable Cloud Input</summary>
+    </key>
+    <key name="cloud-input-source" type="i">
+      <default>0</default>
+      <summary>Cloud Input Source</summary>
+    </key>
+    <key name="cloud-candidates-number" type="i">
+      <default>1</default>
+      <summary>Cloud Candidates Number</summary>
+    </key>
+    <key name="cloud-request-delay-time" type="i">
+      <default>600</default>
+      <summary>Sending Cloud request with delay</summary>
+    </key>
   </schema>
   <schema path="/com/github/libpinyin/ibus-libpinyin/libbopomofo/" id="com.github.libpinyin.ibus-libpinyin.libbopomofo">
     <key name="auxiliary-select-key-f" type="i">
@@ -366,6 +382,22 @@
     <key name="network-dictionary-end-timestamp" type="x">
       <default>0</default>
       <summary>End Timestamp for Network Dictionary</summary>
+    </key>
+    <key name="enable-cloud-input" type="b">
+      <default>false</default>
+      <summary>Enable Cloud Input</summary>
+    </key>
+    <key name="cloud-input-source" type="i">
+      <default>0</default>
+      <summary>Cloud Input Source</summary>
+    </key>
+    <key name="cloud-candidates-number" type="i">
+      <default>1</default>
+      <summary>Cloud Candidates Number</summary>
+    </key>
+    <key name="cloud-request-delay-time" type="i">
+      <default>600</default>
+      <summary>Sending Cloud request with delay</summary>
     </key>
   </schema>
 </schemalist>

--- a/setup/ibus-libpinyin-preferences.ui
+++ b/setup/ibus-libpinyin-preferences.ui
@@ -30,6 +30,20 @@
       </row>
     </data>
   </object>
+  <object class="GtkListStore" id="liststoreCloudInputSource">
+    <columns>
+      <!-- column-name cloud_Input_source -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">Baidu</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Google</col>
+      </row>
+    </data>
+  </object>
   <object class="GtkListStore" id="liststoreDisplayStyle">
     <columns>
       <!-- column-name orientation -->
@@ -141,9 +155,6 @@
     <property name="window_position">center-always</property>
     <property name="icon_name">gtk-preferences</property>
     <property name="type_hint">normal</property>
-    <child>
-      <placeholder/>
-    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="visible">True</property>
@@ -1175,6 +1186,105 @@
                         <property name="position">2</property>
                       </packing>
                     </child>
+                    <child>
+                      <object class="GtkFrame" id="frameCloudInput">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label_xalign">0</property>
+                        <property name="shadow_type">none</property>
+                        <child>
+                          <object class="GtkAlignment" id="alignment5">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="top_padding">6</property>
+                            <property name="left_padding">12</property>
+                            <child>
+                              <object class="GtkVBox" id="vbox17">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                  <object class="GtkCheckButton" id="InitEnableCloudInput">
+                                    <property name="label" translatable="yes">Enable Cloud Input</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="xalign">0.5</property>
+                                    <property name="draw_indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkHBox" id="hbox11">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="spacing">12</property>
+                                    <property name="homogeneous">True</property>
+                                    <child>
+                                      <object class="GtkLabel" id="label41">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="label" translatable="yes">Source From:</property>
+                                        <property name="use_markup">True</property>
+                                        <property name="xalign">0</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBox" id="CloudInputSource">
+                                        <property name="visible">True</property>
+                                        <property name="sensitive">False</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="model">liststoreCloudInputSource</property>
+                                        <property name="button_sensitivity">on</property>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="renderer7"/>
+                                          <attributes>
+                                            <attribute name="text">0</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                        <child type="label">
+                          <object class="GtkLabel" id="label36">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">&lt;b&gt;Cloud Input Option&lt;/b&gt;</property>
+                            <property name="use_markup">True</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">4</property>
+                      </packing>
+                    </child>
                   </object>
                 </child>
               </object>
@@ -1513,6 +1623,105 @@
                         <property name="expand">False</property>
                         <property name="fill">False</property>
                         <property name="position">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkFrame" id="frameBopomofoCloudInput">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label_xalign">0</property>
+                        <property name="shadow_type">none</property>
+                        <child>
+                          <object class="GtkAlignment">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="top_padding">6</property>
+                            <property name="left_padding">12</property>
+                            <child>
+                              <object class="GtkVBox">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                  <object class="GtkCheckButton" id="InitEnableBopomofoCloudInput">
+                                    <property name="label" translatable="yes">Enable Cloud Input</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="xalign">0.5</property>
+                                    <property name="draw_indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkHBox">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="spacing">12</property>
+                                    <property name="homogeneous">True</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="label" translatable="yes">Source From:</property>
+                                        <property name="use_markup">True</property>
+                                        <property name="xalign">0</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBox" id="BopomofoCloudInputSource">
+                                        <property name="visible">True</property>
+                                        <property name="sensitive">False</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="model">liststoreCloudInputSource</property>
+                                        <property name="button_sensitivity">on</property>
+                                        <child>
+                                          <object class="GtkCellRendererText"/>
+                                          <attributes>
+                                            <attribute name="text">0</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                        <child type="label">
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">&lt;b&gt;Cloud Input Option&lt;/b&gt;</property>
+                            <property name="use_markup">True</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">4</property>
                       </packing>
                     </child>
                   </object>
@@ -2326,7 +2535,7 @@ koterpilla, Zerng07, Hillwood Yang
                 </child>
               </object>
               <packing>
-                <property name="position">7</property>
+                <property name="position">8</property>
               </packing>
             </child>
             <child type="tab">
@@ -2336,7 +2545,7 @@ koterpilla, Zerng07, Hillwood Yang
                 <property name="label" translatable="yes">About</property>
               </object>
               <packing>
-                <property name="position">7</property>
+                <property name="position">8</property>
                 <property name="tab_fill">False</property>
               </packing>
             </child>

--- a/setup/main2.py
+++ b/setup/main2.py
@@ -85,6 +85,7 @@ class PreferencesDialog:
             self.__init_dictionary()
             self.__init_user_data()
             self.__init_shortcut()
+            self.__init_cloud_input()
             self.__init_about()
         elif engine == "libbopomofo":
             self.__config_namespace = "com.github.libpinyin.ibus-libpinyin.libbopomofo"
@@ -95,6 +96,7 @@ class PreferencesDialog:
             self.__init_dictionary()
             #self.__init_user_data()
             self.__init_shortcut()
+            self.__init_bopomofo_cloud_input()
             self.__init_about()
             self.__convert_fuzzy_pinyin_to_bopomofo()
             self.__display_style_box.hide()
@@ -114,6 +116,7 @@ class PreferencesDialog:
         self.__page_dictionary = self.__builder.get_object("pageDictionary")
         self.__page_user_data = self.__builder.get_object("pageUserData")
         self.__page_shortcut = self.__builder.get_object("pageShortcut")
+        self.__frame_cloud_input = self.__builder.get_object("frameCloudInput")
         self.__page_about = self.__builder.get_object("pageAbout")
 
         self.__page_general.hide()
@@ -122,6 +125,7 @@ class PreferencesDialog:
         self.__page_fuzzy.hide()
         self.__page_dictionary.hide()
         self.__page_user_data.hide()
+        self.__frame_cloud_input.hide()
         self.__page_about.hide()
 
     def __init_general(self):
@@ -486,6 +490,71 @@ class PreferencesDialog:
 
     def __shortcut_changed_cb(self, editor, key, value):
         self.__set_value(key, value)
+
+    def __init_bopomofo_cloud_input(self):
+        # page Bopomofo CloudInput
+        self.__frame_cloud_input = self.__builder.get_object("frameBopomofoCloudInput")
+
+        # init state
+        self.__init_enable_cloud_input = self.__builder.get_object("InitEnableBopomofoCloudInput")
+
+        # cloud input option
+        self.__cloud_input_source = self.__builder.get_object("BopomofoCloudInputSource")
+
+        # read values
+        self.__init_enable_cloud_input.set_active(self.__get_value("enable-cloud-input"))
+
+        self.__cloud_input_source.set_active(self.__get_value("cloud-input-source"))
+
+        if self.__init_enable_cloud_input.get_active():
+            self.__cloud_input_source.set_sensitive(True)
+        else:
+            self.__cloud_input_source.set_sensitive(False)
+
+        # connect signals
+        def __enable_cloud_input_cb(widget):
+            val = widget.get_active()
+            self.__set_value("enable-cloud-input", val)
+            self.__cloud_input_source.set_sensitive(val)
+
+        def __cloud_input_source_changed_cb(widget):
+            self.__set_value("cloud-input-source", widget.get_active())
+
+        self.__init_enable_cloud_input.connect("toggled", __enable_cloud_input_cb)
+        self.__cloud_input_source.connect("changed", __cloud_input_source_changed_cb)
+
+
+    def __init_cloud_input(self):
+        # page CloudInput
+        self.__frame_cloud_input.show()
+
+        # init state
+        self.__init_enable_cloud_input = self.__builder.get_object("InitEnableCloudInput")
+
+        # cloud input option
+        self.__cloud_input_source = self.__builder.get_object("CloudInputSource")
+
+        # read values
+        self.__init_enable_cloud_input.set_active(self.__get_value("enable-cloud-input"))
+
+        self.__cloud_input_source.set_active(self.__get_value("cloud-input-source"))
+
+        if self.__init_enable_cloud_input.get_active():
+            self.__cloud_input_source.set_sensitive(True)
+        else:
+            self.__cloud_input_source.set_sensitive(False)
+
+        # connect signals
+        def __enable_cloud_input_cb(widget):
+            val = widget.get_active()
+            self.__set_value("enable-cloud-input", val)
+            self.__cloud_input_source.set_sensitive(val)
+
+        def __cloud_input_source_changed_cb(widget):
+            self.__set_value("cloud-input-source", widget.get_active())
+
+        self.__init_enable_cloud_input.connect("toggled", __enable_cloud_input_cb)
+        self.__cloud_input_source.connect("changed", __cloud_input_source_changed_cb)
 
     def __init_about(self):
         # page About

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -105,6 +105,15 @@ ibus_engine_libpinyin_c_sources += \
 	$(NULL)
 endif
 
+if ENABLE_CLOUD_INPUT_MODE
+ibus_engine_libpinyin_h_sources += \
+	PYPCloudCandidates.h \
+	$(NULL)
+ibus_engine_libpinyin_c_sources += \
+	PYPCloudCandidates.cc \
+	$(NULL)
+endif
+
 if IBUS_BUILD_STROKE_INPUT_MODE
 ibus_engine_libpinyin_c_sources += PYStrokeEditor.cc
 endif
@@ -166,6 +175,21 @@ if IBUS_BUILD_LUA_EXTENSION
 	@LUA_LIBS@ \
 	-L../lua/ \
 	-lpylua \
+	$(NULL)
+endif
+
+if ENABLE_CLOUD_INPUT_MODE
+ibus_engine_libpinyin_CXXFLAGS += \
+	@LIBSOUP_CFLAGS@ \
+	@JSONGLIB_CFLAGS@ \
+	-DENABLE_CLOUD_INPUT_MODE \
+	$(NULL)
+endif
+
+if ENABLE_CLOUD_INPUT_MODE
+ibus_engine_libpinyin_LDADD += \
+	@LIBSOUP_LIBS@ \
+	@JSONGLIB_LIBS@ \
 	$(NULL)
 endif
 

--- a/src/PYConfig.cc
+++ b/src/PYConfig.cc
@@ -72,6 +72,11 @@ Config::initDefaultValues (void)
 
     m_network_dictionary_start_timestamp = 0;
     m_network_dictionary_end_timestamp = 0;
+
+    m_enable_cloud_input = FALSE;
+    m_cloud_candidates_number = 1;
+    m_cloud_input_source = BAIDU;
+    m_cloud_request_delay_time = 600;
 }
 
 

--- a/src/PYConfig.h
+++ b/src/PYConfig.h
@@ -38,6 +38,11 @@ typedef enum {
     DISPLAY_STYLE_COMPACT
 } DisplayStyle;
 
+enum CloudInputSource{
+    BAIDU = 0,
+    GOOGLE
+};
+
 class Config {
 protected:
     Config (const std::string & name);
@@ -89,6 +94,11 @@ public:
     { return FALSE; }
     virtual gboolean networkDictionaryEndTimestamp (gint64 timestamp)
     { return FALSE; }
+
+    gboolean enableCloudInput (void) const      { return m_enable_cloud_input; }
+    guint cloudInputSource (void) const         { return m_cloud_input_source; }
+    guint cloudCandidatesNumber (void) const    { return m_cloud_candidates_number; }
+    guint cloudRequestDelayTime (void) const    { return m_cloud_request_delay_time; }
 
 protected:
     bool read (const gchar * name, bool defval);
@@ -157,6 +167,11 @@ protected:
 
     gint64 m_network_dictionary_start_timestamp;
     gint64 m_network_dictionary_end_timestamp;
+
+    gboolean m_enable_cloud_input;
+    guint m_cloud_input_source;
+    guint m_cloud_candidates_number;
+    guint m_cloud_request_delay_time;
 };
 
 

--- a/src/PYPBopomofoEditor.cc
+++ b/src/PYPBopomofoEditor.cc
@@ -46,6 +46,10 @@ BopomofoEditor::BopomofoEditor
       m_select_mode (FALSE)
 {
     m_instance = LibPinyinBackEnd::instance ().allocChewingInstance ();
+
+#ifdef ENABLE_CLOUD_INPUT_MODE
+    m_cloud_candidates.setInputMode (Bopomofo);
+#endif
 }
 
 BopomofoEditor::~BopomofoEditor (void)

--- a/src/PYPCloudCandidates.cc
+++ b/src/PYPCloudCandidates.cc
@@ -1,0 +1,694 @@
+/* vim:set et ts=4 sts=4:
+ *
+ * ibus-libpinyin - Intelligent Pinyin engine based on libpinyin for IBus
+ *
+ * Copyright (c) 2018 linyu Xu <liannaxu07@gmail.com>
+ * Copyright (c) 2020 Weixuan XIAO <veyx.shaw@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include "PYPCloudCandidates.h"
+#include "PYString.h"
+#include "PYConfig.h"
+#include "PYPPhoneticEditor.h"
+#include "PYPPinyinEditor.h"
+
+#include <assert.h>
+#include <pinyin.h>
+#include <cstring>
+#include <glib.h>
+
+
+using namespace PY;
+
+enum CandidateResponseParserError {
+    PARSER_NOERR,
+    PARSER_INVALID_DATA,
+    PARSER_BAD_FORMAT,
+    PARSER_NO_CANDIDATE,
+    PARSER_NETWORK_ERROR,
+    PARSER_UNKNOWN
+};
+
+static const std::string CANDIDATE_CLOUD_PREFIX = "☁";
+
+static const std::string CANDIDATE_PENDING_TEXT_WITHOUT_PREFIX      = "[⏱]";
+static const std::string CANDIDATE_LOADING_TEXT_WITHOUT_PREFIX      = "...";
+static const std::string CANDIDATE_NO_CANDIDATE_TEXT_WITHOUT_PREFIX = "[🚫]";
+static const std::string CANDIDATE_INVALID_DATA_TEXT_WITHOUT_PREFIX = "[❌]";
+static const std::string CANDIDATE_BAD_FORMAT_TEXT_WITHOUT_PREFIX   = "[❓]";
+
+static const std::string CANDIDATE_PENDING_TEXT         = CANDIDATE_CLOUD_PREFIX + CANDIDATE_PENDING_TEXT_WITHOUT_PREFIX;
+static const std::string CANDIDATE_LOADING_TEXT         = CANDIDATE_CLOUD_PREFIX + CANDIDATE_LOADING_TEXT_WITHOUT_PREFIX;
+static const std::string CANDIDATE_NO_CANDIDATE_TEXT    = CANDIDATE_CLOUD_PREFIX + CANDIDATE_NO_CANDIDATE_TEXT_WITHOUT_PREFIX;
+static const std::string CANDIDATE_INVALID_DATA_TEXT    = CANDIDATE_CLOUD_PREFIX + CANDIDATE_INVALID_DATA_TEXT_WITHOUT_PREFIX ;
+static const std::string CANDIDATE_BAD_FORMAT_TEXT      = CANDIDATE_CLOUD_PREFIX + CANDIDATE_BAD_FORMAT_TEXT_WITHOUT_PREFIX;
+
+static const char *BAIDU_URL_TEMPLATE = "http://olime.baidu.com/py?input=%s&inputtype=py&bg=0&ed=%d&result=hanzi&resultcoding=utf-8&ch_en=1&clientinfo=web&version=1";
+static const char *GOOGLE_URL_TEMPLATE = "https://www.google.com/inputtools/request?ime=pinyin&text=%s&num=%d";
+
+typedef struct
+{
+    guint event_id;
+    gchar request_str[MAX_PINYIN_LEN + 1];
+    CloudCandidates *cloud_candidates;
+} DelayedCloudAsyncRequestCallbackUserData;
+
+class CloudCandidatesResponseParser
+{
+public:
+    CloudCandidatesResponseParser () : m_annotation (NULL) {}
+    virtual ~CloudCandidatesResponseParser () {}
+
+    virtual guint parse (GInputStream *stream) = 0;
+
+    virtual std::vector<std::string> &getStringCandidates () { return m_candidates; }
+    virtual const gchar *getAnnotation () { return m_annotation; }
+
+protected:
+    std::vector<std::string> m_candidates;
+    const gchar *m_annotation;
+};
+
+class CloudCandidatesResponseJsonParser : public CloudCandidatesResponseParser
+{
+public:
+    CloudCandidatesResponseJsonParser ();
+    virtual ~CloudCandidatesResponseJsonParser ();
+
+    guint parse (GInputStream *stream)
+    {
+        GError **error = NULL;
+
+        if (!stream)
+            return PARSER_NETWORK_ERROR;
+
+        /* parse Json from input steam */
+        if (!json_parser_load_from_stream (m_parser, stream, NULL, error) || error != NULL) {
+            g_input_stream_close (stream, NULL, error);  /* Close stream to release libsoup connexion */
+            return PARSER_BAD_FORMAT;
+        }
+        g_input_stream_close (stream, NULL, error);  /* Close stream to release libsoup connexion */
+
+        return parseJsonResponse (json_parser_get_root (m_parser));
+    }
+
+protected:
+    JsonParser *m_parser;
+
+    virtual guint parseJsonResponse (JsonNode *root) = 0;
+};
+
+class GoogleCloudCandidatesResponseJsonParser : public CloudCandidatesResponseJsonParser
+{
+protected:
+    guint parseJsonResponse (JsonNode *root)
+    {
+        /* clear the last result */
+        m_candidates.clear ();
+
+        if (!JSON_NODE_HOLDS_ARRAY (root))
+            return PARSER_BAD_FORMAT;
+
+        /* validate Google source and the structure of response */
+        JsonArray *google_root_array = json_node_get_array (root);
+
+        /**
+         * declare variables to refer to structures in the result
+         * a typical cloud candidate response from Google is:
+         * [                        <- google_root_array
+         *  "SUCCESS",                  <- google_response_status
+         *  [                           <- google_response_array
+         *      [                           <- google_result_array
+         *          "ceshi",                    <- google_candidate_annotation
+         *          ["测试"],                    <- google_candidate_array
+         *          [],
+         *          {
+         *              "annotation":["ce shi"],
+         *              "candidate_type":[0],
+         *              "lc":["16 16"]
+         *          }
+         *      ]                           <- google_result_array end
+         *  ]                           <- google_response_array end
+         * ]                        <- google_root_array end
+         */
+        const gchar *google_response_status;
+        JsonArray *google_response_array;
+        JsonArray *google_result_array;
+        const gchar *google_candidate_annotation;
+        JsonArray *google_candidate_array;
+        guint result_counter;
+
+        /* validate google_root_array length */
+        if (json_array_get_length (google_root_array) <= 1)
+            return PARSER_INVALID_DATA;
+
+        /* get and validate google_response_status */
+        google_response_status = json_array_get_string_element (google_root_array, 0);
+        if (g_strcmp0 (google_response_status, "SUCCESS"))
+            return PARSER_INVALID_DATA;
+
+        /* get google_response_array */
+        google_response_array = json_array_get_array_element (google_root_array, 1);
+
+        /* validate google_response_array length */
+        if (json_array_get_length (google_response_array) < 1)
+            return PARSER_INVALID_DATA;
+
+        /* get google_result_array */
+        google_result_array = json_array_get_array_element (google_response_array, 0);
+
+        /* get and validate google_candidate_annotation */
+        google_candidate_annotation = json_array_get_string_element (google_result_array, 0);
+        if (!google_candidate_annotation)
+            return PARSER_INVALID_DATA;
+
+        /* update annotation with the parsed annotation */
+        m_annotation = google_candidate_annotation;
+
+        /* get google_candidate_array */
+        google_candidate_array = json_array_get_array_element (google_result_array, 1);
+
+        /* there should be at least one candidate */
+        result_counter = json_array_get_length (google_candidate_array);
+        if (result_counter < 1)
+            return PARSER_NO_CANDIDATE;
+
+        /* put all parsed candidates into m_candidates array of parser instance */
+        for (guint i = 0; i < result_counter; ++i) {
+            std::string candidate = json_array_get_string_element (google_candidate_array, i);
+            m_candidates.push_back (candidate);
+        }
+
+        return PARSER_NOERR;
+    }
+
+public:
+    GoogleCloudCandidatesResponseJsonParser () : CloudCandidatesResponseJsonParser () {}
+};
+
+class BaiduCloudCandidatesResponseJsonParser : public CloudCandidatesResponseJsonParser
+{
+private:
+    guint parseJsonResponse (JsonNode *root)
+    {
+        /* clear the last result */
+        m_candidates.clear ();
+
+        if (!JSON_NODE_HOLDS_OBJECT (root))
+            return PARSER_BAD_FORMAT;
+
+        /* validate Baidu source and the structure of response */
+        JsonObject *baidu_root_object = json_node_get_object (root);
+
+        /**
+         * declare variables to refer to structures in the result
+         * a typical cloud candidate response from Baidu is:
+         * {                <- baidu_root_object
+         *  "errmsg":"",
+         *  "errno":"0",
+         *  "result":
+         *      [               <- baidu_result_array
+         *          [               <- baidu_candidate_array
+         *              [               <- baidu_candidate
+         *                  "测试",
+         *                  5,
+         *                  {
+         *                      "pinyin":"ce'shi",
+         *                      "type":"IMEDICT"
+         *                  }
+         *              ]               <- baidu_candidate end
+         *          ],              <- baidu_candidate_array end
+         *          "ce'shi"        <- baidu_candidate_annotation
+         *      ],              <- baidu_result_array end
+         *  "status":"T"        <- baidu_response_status
+         * }                <- baidu_root_object end
+         */
+        const gchar *baidu_response_status;
+        JsonArray *baidu_result_array;
+        JsonArray *baidu_candidate_array;
+        const gchar *baidu_candidate_annotation;
+        guint result_counter;
+
+        /* get and validate baidu_response_status */
+        if (!json_object_has_member (baidu_root_object, "status"))
+            return PARSER_INVALID_DATA;
+        baidu_response_status = json_object_get_string_member (baidu_root_object, "status");
+        if (g_strcmp0 (baidu_response_status, "T"))
+            return PARSER_INVALID_DATA;
+
+        /* get baidu_result_array */
+        if (!json_object_has_member (baidu_root_object, "result"))
+            return PARSER_INVALID_DATA;
+        baidu_result_array = json_object_get_array_member (baidu_root_object, "result");
+
+        /* get baidu_candidate_array and baidu_candidate_annotation */
+        if (json_array_get_length (baidu_result_array) < 2)
+            return PARSER_INVALID_DATA;
+        baidu_candidate_array = json_array_get_array_element (baidu_result_array, 0);
+        baidu_candidate_annotation = json_array_get_string_element (baidu_result_array, 1);
+
+        /* validate baidu_candidate_annotation */
+        if (!baidu_candidate_annotation)
+            return PARSER_INVALID_DATA;
+
+        /* update annotation with the returned annotation */
+        m_annotation = baidu_candidate_annotation;
+
+        /* there should be at least one candidate */
+        result_counter = json_array_get_length (baidu_candidate_array);
+        if (result_counter < 1)
+            return PARSER_NO_CANDIDATE;
+
+        /* visit all baidu_candidate */
+        for (guint i = 0; i < result_counter; ++i) {
+            std::string candidate;
+            JsonArray *baidu_candidate = json_array_get_array_element (baidu_candidate_array, i);
+
+            /* confirm the candidate exists in this baidu_candidate */
+            if (json_array_get_length (baidu_candidate) < 1)
+                candidate = CANDIDATE_INVALID_DATA_TEXT_WITHOUT_PREFIX;
+            else
+                candidate = json_array_get_string_element (baidu_candidate, 0);
+
+            /* put all parsed candidates into m_candidates array of parser instance */
+            m_candidates.push_back (candidate);
+        }
+
+        return PARSER_NOERR;
+    }
+
+public:
+    BaiduCloudCandidatesResponseJsonParser () : CloudCandidatesResponseJsonParser () {}
+    ~BaiduCloudCandidatesResponseJsonParser () { if (m_annotation) g_free ((gpointer)m_annotation); }
+};
+
+gboolean
+CloudCandidates::delayedCloudAsyncRequestCallBack (gpointer user_data)
+{
+    DelayedCloudAsyncRequestCallbackUserData *data = static_cast<DelayedCloudAsyncRequestCallbackUserData *> (user_data);
+    CloudCandidates *cloudCandidates;
+
+    if (!data)
+        return FALSE;
+
+    cloudCandidates = data->cloud_candidates;
+
+    if (!cloudCandidates)
+        return FALSE;
+
+    /* only send with a latest timer */
+    if (data->event_id == cloudCandidates->m_source_event_id) {
+        cloudCandidates->m_source_event_id = 0;
+        cloudCandidates->cloudAsyncRequest (data->request_str);
+    }
+
+    return FALSE;
+}
+
+void
+CloudCandidates::delayedCloudAsyncRequestDestroyCallBack (gpointer user_data)
+{
+    /* clean up */
+    if (user_data)
+        g_free (user_data);
+}
+
+CloudCandidates::CloudCandidates (PhoneticEditor * editor) : m_input_mode(FullPinyin)
+{
+    m_session = soup_session_new ();
+    m_editor = editor;
+
+    m_source_event_id = 0;
+    m_message = NULL;
+
+    m_baidu_parser = new BaiduCloudCandidatesResponseJsonParser ();
+    m_google_parser = new GoogleCloudCandidatesResponseJsonParser ();
+}
+
+CloudCandidates::~CloudCandidates ()
+{
+    if (m_source_event_id != 0) {
+        g_source_remove (m_source_event_id);
+        m_source_event_id = 0;
+    }
+
+    if (m_message) {
+        soup_session_cancel_message (m_session, m_message, SOUP_STATUS_CANCELLED);
+        m_message = NULL;
+    }
+
+    if (m_session) {
+        g_object_unref (m_session);
+        m_session = NULL;
+    }
+
+    if (m_baidu_parser) {
+        delete m_baidu_parser;
+        m_baidu_parser = NULL;
+    }
+
+    if (m_google_parser) {
+        delete m_google_parser;
+        m_google_parser = NULL;
+    }
+}
+
+gboolean
+CloudCandidates::processCandidates (std::vector<EnhancedCandidate> & candidates)
+{
+    /* refer pinyin retrieved in full pinyin mode */
+    String full_pinyin_text;
+
+    /* find the first position after n-gram candidates */
+    std::vector<EnhancedCandidate>::iterator first_pos;
+
+    /* check the length of candidates */
+    if (0 == candidates.size ())
+        return FALSE;   /* no candidate */
+
+    const String & display_string = candidates[0].m_display_string;
+    if (display_string.utf8Length () < CLOUD_MINIMUM_UTF8_TRIGGER_LENGTH) {
+        m_last_requested_pinyin = "";
+        return FALSE;   /* do not request because there is only one character */
+    }
+
+    /* search the first non-ngram candidate */
+    for (first_pos = candidates.begin (); first_pos != candidates.end (); ++first_pos) {
+        if (CANDIDATE_NBEST_MATCH != first_pos->m_candidate_type)
+            break;
+    }
+
+    /* neither double pinyin mode nor bopomofo mode */
+    if (m_input_mode == FullPinyin)
+        full_pinyin_text = m_editor->m_text;
+    else
+        full_pinyin_text = getFullPinyin ();
+
+    if (m_last_requested_pinyin == full_pinyin_text) {
+        /* do not request again and update cached ones */
+
+        for (int i = 0; i < m_candidates.size (); ++i){
+            EnhancedCandidate candidate = m_candidates[i];
+            /* insert cloud prefix */
+            candidate.m_display_string = CANDIDATE_CLOUD_PREFIX + candidate.m_display_string;
+            candidates.insert (first_pos + i, candidate);
+        }
+        return TRUE;
+    }
+
+    /* have cloud candidates already */
+    if (first_pos->m_candidate_type == CANDIDATE_CLOUD_INPUT)
+        return FALSE;
+
+    /* insert cloud candidates' placeholders */
+    m_candidates.clear ();
+    for (guint i = 0; i < m_editor->m_config.cloudCandidatesNumber (); ++i) {
+        EnhancedCandidate enhanced;
+        enhanced.m_candidate_id = i;
+        enhanced.m_display_string = CANDIDATE_PENDING_TEXT;
+        enhanced.m_candidate_type = CANDIDATE_CLOUD_INPUT;
+        m_candidates.push_back (enhanced);
+    }
+    candidates.insert (first_pos, m_candidates.begin (), m_candidates.end ());
+
+    delayedCloudAsyncRequest (full_pinyin_text);
+
+    return TRUE;
+}
+
+int
+CloudCandidates::selectCandidate (EnhancedCandidate & enhanced)
+{
+    assert (CANDIDATE_CLOUD_INPUT == enhanced.m_candidate_type);
+
+    if (enhanced.m_display_string == CANDIDATE_PENDING_TEXT ||
+        enhanced.m_display_string == CANDIDATE_LOADING_TEXT ||
+        enhanced.m_display_string == CANDIDATE_BAD_FORMAT_TEXT ||
+        enhanced.m_display_string == CANDIDATE_INVALID_DATA_TEXT)
+        return SELECT_CANDIDATE_ALREADY_HANDLED;
+
+    if (enhanced.m_candidate_id < m_candidates.size ()) {
+        enhanced.m_display_string =
+            m_candidates[enhanced.m_candidate_id].m_display_string;
+
+        /* modify in-place and commit */
+        return SELECT_CANDIDATE_COMMIT | SELECT_CANDIDATE_MODIFY_IN_PLACE;
+    }
+
+    return SELECT_CANDIDATE_ALREADY_HANDLED;
+}
+
+void
+CloudCandidates::delayedCloudAsyncRequest (const gchar* request_str)
+{
+    gpointer user_data;
+    DelayedCloudAsyncRequestCallbackUserData *data;
+
+    /* cancel the latest timer, if applied */
+    if (m_source_event_id != 0)
+        g_source_remove (m_source_event_id);
+
+    /* allocate memory for a DelayedCloudAsyncRequestCallbackUserData instance to take more callback user data */
+    user_data = g_malloc (sizeof(DelayedCloudAsyncRequestCallbackUserData));
+    data = static_cast<DelayedCloudAsyncRequestCallbackUserData *> (user_data);
+
+    strncpy (data->request_str, request_str, MAX_PINYIN_LEN);
+    data->request_str[MAX_PINYIN_LEN] = '\0';
+    data->cloud_candidates = this;
+
+    /* record the latest timer */
+    m_source_event_id = g_timeout_add_full (G_PRIORITY_DEFAULT,
+                                            m_editor->m_config.cloudRequestDelayTime (),
+                                            delayedCloudAsyncRequestCallBack,
+                                            user_data,
+                                            delayedCloudAsyncRequestDestroyCallBack);
+    data->event_id = m_source_event_id;
+}
+
+void
+CloudCandidates::cloudAsyncRequest (const gchar* request_str)
+{
+    GError **error = NULL;
+    gchar *query_request;
+    guint cloud_source = m_editor->m_config.cloudInputSource ();
+    guint cloud_candidates_number = m_editor->m_config.cloudCandidatesNumber ();
+
+    if (cloud_source == BAIDU)
+        query_request= g_strdup_printf (BAIDU_URL_TEMPLATE, request_str, cloud_candidates_number);
+    else if (cloud_source == GOOGLE)
+        query_request= g_strdup_printf (GOOGLE_URL_TEMPLATE, request_str, cloud_candidates_number);
+
+    /* cancel message if there is a pending one */
+    if (m_message)
+        soup_session_cancel_message (m_session, m_message, SOUP_STATUS_CANCELLED);
+
+    SoupMessage *msg = soup_message_new ("GET", query_request);
+    soup_session_send_async (m_session, msg, NULL, cloudResponseCallBack, static_cast<gpointer> (this));
+    m_message = msg;
+
+    /* cache the last request string */
+    m_last_requested_pinyin = request_str;
+
+    /* update loading text to replace pending text */
+    for (std::vector<EnhancedCandidate>::iterator pos = m_candidates.begin (); pos != m_candidates.end (); ++pos) {
+        pos->m_display_string = CANDIDATE_LOADING_TEXT_WITHOUT_PREFIX;
+    }
+
+    /* only update lookup table when there is still pinyin text */
+    if (m_editor->m_text.utf8Length () >= CLOUD_MINIMUM_UTF8_TRIGGER_LENGTH)
+        updateLookupTable ();
+
+    /* free url string */
+    if (query_request)
+        g_free(query_request);
+}
+
+void
+CloudCandidates::cloudResponseCallBack (GObject *source_object, GAsyncResult *result, gpointer user_data)
+{
+    GError **error = NULL;
+    GInputStream *stream = soup_session_send_finish (SOUP_SESSION (source_object), result, error);
+    CloudCandidates *cloudCandidates = static_cast<CloudCandidates *> (user_data);
+
+    /* process results */
+    cloudCandidates->processCloudResponse (stream, cloudCandidates->m_editor->m_candidates);
+
+    /* only update lookup table when there is still pinyin text */
+    if (cloudCandidates->m_editor->m_text.utf8Length () >=
+        CLOUD_MINIMUM_UTF8_TRIGGER_LENGTH) {
+        cloudCandidates->updateLookupTable ();
+
+        /* clean up message */
+        cloudCandidates->m_message = NULL;
+    }
+}
+
+void
+CloudCandidates::cloudSyncRequest (const gchar* request_str, std::vector<EnhancedCandidate> & candidates)
+{
+    GError **error = NULL;
+    gchar *queryRequest;
+    guint cloud_source = m_editor->m_config.cloudInputSource ();
+    guint cloud_candidates_number = m_editor->m_config.cloudCandidatesNumber ();
+
+    if (cloud_source == BAIDU)
+        queryRequest= g_strdup_printf (BAIDU_URL_TEMPLATE, request_str, cloud_candidates_number);
+    else if (cloud_source == GOOGLE)
+        queryRequest= g_strdup_printf (GOOGLE_URL_TEMPLATE, request_str, cloud_candidates_number);
+    SoupMessage *msg = soup_message_new ("GET", queryRequest);
+
+    GInputStream *stream = soup_session_send (m_session, msg, NULL, error);
+
+    processCloudResponse (stream, candidates);
+}
+
+void
+CloudCandidates::processCloudResponse (GInputStream *stream, std::vector<EnhancedCandidate> & candidates)
+{
+    guint retval;
+    CloudCandidatesResponseJsonParser *parser = NULL;
+    String text;
+    gchar annotation[MAX_PINYIN_LEN + 1];
+    guint cloud_source = m_editor->m_config.cloudInputSource ();
+
+    if (cloud_source == BAIDU)
+        parser = m_baidu_parser;
+    else if (cloud_source == GOOGLE)
+        parser = m_google_parser;
+
+    retval = parser->parse (stream);
+
+    /* no annotation if there is NETWORK_ERROR, process before detecting parsed annotation */
+    if (retval == PARSER_NETWORK_ERROR) {
+        for (std::vector<EnhancedCandidate>::iterator pos = m_candidates.begin (); pos != m_candidates.end (); ++pos) {
+            pos->m_display_string = CANDIDATE_INVALID_DATA_TEXT_WITHOUT_PREFIX;
+        }
+    }
+
+    if (parser->getAnnotation ())
+        strncpy (annotation, parser->getAnnotation (), MAX_PINYIN_LEN);
+    else /* the request might have been cancelled */
+        return;
+
+    if (m_input_mode == FullPinyin) {
+        /* get current text in editor */
+        text = m_editor->m_text;
+    } else {
+        /* get current text */
+        text = getFullPinyin ();
+    }
+
+    /* ignore annotation match while using Baidu source */
+    if (cloud_source == BAIDU || !g_strcmp0 (annotation, text)) {
+        if (retval == PARSER_NOERR) {
+            /* update to the cached candidates list */
+            std::vector<std::string> &updated = parser->getStringCandidates ();
+            assert (m_candidates.size () == updated.size ());
+
+            for (guint i = 0; i < m_candidates.size (); ++i) {
+                /* cache candidate without prefix in m_candidates */
+                m_candidates[i].m_display_string = updated[i];
+            }
+        }
+        else {
+            String display_text;
+
+            switch (retval) {
+            case PARSER_NO_CANDIDATE:
+                display_text = CANDIDATE_NO_CANDIDATE_TEXT_WITHOUT_PREFIX;
+                break;
+            case PARSER_INVALID_DATA:
+                display_text = CANDIDATE_INVALID_DATA_TEXT_WITHOUT_PREFIX;
+                break;
+            case PARSER_BAD_FORMAT:
+                display_text = CANDIDATE_BAD_FORMAT_TEXT_WITHOUT_PREFIX;
+                break;
+            }
+
+            for (std::vector<EnhancedCandidate>::iterator pos = m_candidates.begin (); pos != m_candidates.end (); ++pos) {
+                pos->m_display_string = display_text;
+            }
+        }
+    }
+}
+
+void
+CloudCandidates::updateLookupTable ()
+{
+    /* retrieve cursor position in lookup table */
+    guint cursor = m_editor->m_lookup_table.cursorPos ();
+
+    /* update cached cloud input candidates */
+    m_editor->updateCandidates ();
+
+    /* regenerate lookup table */
+    m_editor->m_lookup_table.clear ();
+    m_editor->fillLookupTable ();
+
+    /* recover cursor position in lookup table */
+    m_editor->m_lookup_table.setCursorPos (cursor);
+
+    /* notify ibus */
+    m_editor->updateLookupTableFast ();
+}
+
+String
+CloudCandidates::getFullPinyin ()
+{
+    String buffer;
+
+    gchar * aux_text                = NULL;
+    gchar * pinyin_text             = NULL;
+    gchar * pinyin_text_with_quote  = NULL;
+    gchar** tempArray               = NULL;
+
+    /* get full pinyin auxiliary text */
+    pinyin_get_full_pinyin_auxiliary_text (m_editor->m_instance, m_editor->m_cursor, &aux_text);
+
+    /* remove tone and cursor */
+    tempArray =  g_strsplit_set (aux_text, "|12345", -1);
+    pinyin_text = g_strjoinv ("", tempArray);
+    g_strfreev (tempArray);
+
+    /* remove space */
+    pinyin_text = g_strstrip(pinyin_text);
+
+    /* replace space with quote */
+    tempArray =  g_strsplit_set (pinyin_text, " ", -1);
+    pinyin_text_with_quote = g_strjoinv ("'", tempArray);
+    buffer << pinyin_text_with_quote;
+    g_strfreev (tempArray);
+
+    /* free */
+    g_free(aux_text);
+    g_free(pinyin_text);
+    g_free(pinyin_text_with_quote);
+
+    return buffer;
+}
+
+CloudCandidatesResponseJsonParser::CloudCandidatesResponseJsonParser () : m_parser (NULL)
+{
+    m_parser = json_parser_new ();
+}
+
+CloudCandidatesResponseJsonParser::~CloudCandidatesResponseJsonParser ()
+{
+    /* free json parser object if necessary */
+    if (m_parser)
+        g_object_unref (m_parser);
+}

--- a/src/PYPCloudCandidates.h
+++ b/src/PYPCloudCandidates.h
@@ -1,0 +1,99 @@
+/* vim:set et ts=4 sts=4:
+ *
+ * ibus-libpinyin - Intelligent Pinyin engine based on libpinyin for IBus
+ *
+ * Copyright (c) 2018 linyu Xu <liannaxu07@gmail.com>
+ * Copyright (c) 2020 Weixuan XIAO <veyx.shaw@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef __PY_LIB_PINYIN_ClOUD_CANDIDATES_H_
+#define __PY_LIB_PINYIN_ClOUD_CANDIDATES_H_
+
+#include "PYString.h"
+#include "PYPointer.h"
+#include "PYPEnhancedCandidates.h"
+#include <vector>
+#include <libsoup/soup.h>
+#include <json-glib/json-glib.h>
+#include "PYConfig.h"
+
+
+
+class BaiduCloudCandidatesResponseJsonParser;
+class GoogleCloudCandidatesResponseJsonParser;
+
+namespace PY {
+
+#define BUFFERLENGTH 2048
+#define CLOUD_MINIMUM_UTF8_TRIGGER_LENGTH 2
+
+enum InputMode {
+    FullPinyin = 0,
+    DoublePinyin,
+    Bopomofo
+};
+
+class PhoneticEditor;
+
+class CloudCandidates : public EnhancedCandidates<PhoneticEditor>
+{
+public:
+
+    CloudCandidates (PhoneticEditor *editor);
+    ~CloudCandidates();
+
+    void setInputMode (InputMode mode) { m_input_mode = mode; }
+
+    gboolean processCandidates (std::vector<EnhancedCandidate> & candidates);
+
+    int selectCandidate (EnhancedCandidate & enhanced);
+
+    void cloudAsyncRequest (const gchar* requestStr);
+    void cloudSyncRequest (const gchar* requestStr, std::vector<EnhancedCandidate> & candidates);
+
+    void delayedCloudAsyncRequest (const gchar* requestStr);
+
+    void updateLookupTable ();
+
+    guint m_source_event_id;
+    SoupMessage *m_message;
+    std::string m_last_requested_pinyin;
+
+private:
+    static gboolean delayedCloudAsyncRequestCallBack (gpointer user_data);
+    static void delayedCloudAsyncRequestDestroyCallBack (gpointer user_data);
+    static void cloudResponseCallBack (GObject *object, GAsyncResult *result, gpointer user_data);
+
+    void processCloudResponse (GInputStream *stream, std::vector<EnhancedCandidate> & candidates);
+
+    /* get internal full pinyin representation */
+    String getFullPinyin ();
+private:
+    SoupSession *m_session;
+    InputMode m_input_mode;
+
+    BaiduCloudCandidatesResponseJsonParser *m_baidu_parser;
+    GoogleCloudCandidatesResponseJsonParser *m_google_parser;
+protected:
+    std::vector<EnhancedCandidate> m_candidates;
+};
+
+};
+
+#endif
+
+

--- a/src/PYPDoublePinyinEditor.cc
+++ b/src/PYPDoublePinyinEditor.cc
@@ -41,6 +41,10 @@ DoublePinyinEditor::DoublePinyinEditor
     : PinyinEditor (props, config)
 {
     m_instance = LibPinyinBackEnd::instance ().allocPinyinInstance ();
+
+#ifdef ENABLE_CLOUD_INPUT_MODE
+    m_cloud_candidates.setInputMode (DoublePinyin);
+#endif
 }
 
 DoublePinyinEditor::~DoublePinyinEditor (void)

--- a/src/PYPPhoneticEditor.cc
+++ b/src/PYPPhoneticEditor.cc
@@ -37,6 +37,9 @@ PhoneticEditor::PhoneticEditor (PinyinProperties &props,
     m_lua_converter_candidates (this),
 #endif
     m_emoji_candidates (this),
+#ifdef ENABLE_CLOUD_INPUT_MODE
+    m_cloud_candidates(this),
+#endif
     m_traditional_candidates (this, config)
 {
 }
@@ -239,6 +242,12 @@ PhoneticEditor::updateCandidates (void)
     }
 #endif
 
+#ifdef ENABLE_CLOUD_INPUT_MODE
+    /* keep me behind the other kinds of candidates which are inserted after n-gram candidates */
+    if(m_config.enableCloudInput ())
+        m_cloud_candidates.processCandidates (m_candidates);
+#endif
+
     if (!m_props.modeSimp ())
         m_traditional_candidates.processCandidates (m_candidates);
 
@@ -366,6 +375,11 @@ PhoneticEditor::selectCandidateInternal (EnhancedCandidate & candidate)
 
     case CANDIDATE_TRADITIONAL_CHINESE:
         return m_traditional_candidates.selectCandidate (candidate);
+
+#ifdef ENABLE_CLOUD_INPUT_MODE
+    case CANDIDATE_CLOUD_INPUT:
+        return m_cloud_candidates.selectCandidate (candidate);
+#endif
 
 #ifdef IBUS_BUILD_LUA_EXTENSION
     case CANDIDATE_LUA_TRIGGER:

--- a/src/PYPPhoneticEditor.h
+++ b/src/PYPPhoneticEditor.h
@@ -39,10 +39,15 @@
 
 #include "PYPEmojiCandidates.h"
 
+#ifdef ENABLE_CLOUD_INPUT_MODE
+#include "PYPCloudCandidates.h"
+#endif
+
 namespace PY {
 
 class PhoneticEditor : public Editor {
     friend class LibPinyinCandidates;
+    friend class CloudCandidates;
 
 public:
     PhoneticEditor (PinyinProperties & props, Config & config);
@@ -125,6 +130,10 @@ protected:
     EmojiCandidates m_emoji_candidates;
 
     TraditionalCandidates m_traditional_candidates;
+
+#ifdef ENABLE_CLOUD_INPUT_MODE
+    CloudCandidates m_cloud_candidates;
+#endif
 };
 
 };


### PR DESCRIPTION
This brings Cloud Input feature to `ibus-libpinyin`:

- Asynchronous request: the network request will not block the behaviour of Input Method Engine, which brings better user experience;
- Delayed request: request will be sent when user stops typing, this can reduce Cloud Input server load and avoid redundant, useless requests;
- Response data validation: do a validation on the response content to make sure the data is complete and prevent crash;
- Cancellable request: the request already sent can be cancelled when the user is to type new content.

It supports all 3 input methods:

- Full Pinyin
- Double Pinyin
- Bopomofo



