### PR TITLE
Drop the deprecated `loadstring` method

### DIFF
--- a/lua/base.lua
+++ b/lua/base.lua
@@ -161,7 +161,7 @@ end
 
 function compute(input)
   local expr = "return " .. _add_math_keyword(input)
-  local func = loadstring(expr)
+  local func = load(expr)
   if func == nil then
     return "-- 未完整表达式 --"
   end


### PR DESCRIPTION
 `loadstring` has been replaced by `load` since [Lua 5.2](http://www.lua.org/manual/5.2/manual.html#8.2), which makes the command `js` unresponsive with Lua 5.4.