### PR TITLE
Change deprecated glib function g_atexit() into atexit()

### DIFF
--- a/src/PYMain.cc
+++ b/src/PYMain.cc
@@ -180,7 +180,7 @@ main (gint argc, gchar **argv)
 
     ::signal (SIGTERM, sigterm_cb);
     ::signal (SIGINT, sigterm_cb);
-    g_atexit (atexit_cb);
+    atexit (atexit_cb);
 
     start_component ();
     return 0;


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/43995067/111898002-28bd8500-8a5e-11eb-971f-ac286dc68ccd.png)

Referring to: https://developer.gnome.org/glib/stable/glib-Miscellaneous-Utility-Functions.html#g-atexit

Tested after making this change, everything looks good!

Signed-off-by: Hollow Man <hollowman@hollowman.ml>