### PR TITLE
Fix space

### DIFF
--- a/src/PYPPhoneticEditor.cc
+++ b/src/PYPPhoneticEditor.cc
@@ -67,7 +67,7 @@ PhoneticEditor::processSpace (guint keyval, guint keycode,
     if (!m_text)
         return FALSE;
     if (cmshm_filter (modifiers) != 0)
-        return TRUE;
+        return FALSE;
 
     if (m_lookup_table.size () != 0) {
         selectCandidate (m_lookup_table.cursorPos ());


### PR DESCRIPTION
这里什么都没做应该返回FALSE吧？
如果是TRUE导致m_prev_pressed_key等于IBUS_VoidSymbol
对于习惯用Ctrl+space来切换输入法的 中文切换英文的时候有输入的时候无法成功 
```
        if (m_prev_pressed_key == keyval) {
            if (PinyinConfig::instance ().mainSwitch () == accel) {
                triggered = TRUE;
            }
        }
```