### PR TITLE
build: fix awk scripts to work properly when used againts sqlite 3.41.0

### DIFF
--- a/data/english.awk
+++ b/data/english.awk
@@ -5,9 +5,9 @@ BEGIN {
     print "BEGIN TRANSACTION;"
 
     # Create english table
-    print "CREATE TABLE IF NOT EXISTS \"english\" ( "   \
-        "\"word\" TEXT NOT NULL PRIMARY KEY,"           \
-        "\"freq\" FLOAT NOT NULL DEFAULT(0)"            \
+    print "CREATE TABLE IF NOT EXISTS 'english' ( "   \
+        "'word' TEXT NOT NULL PRIMARY KEY,"           \
+        "'freq' FLOAT NOT NULL DEFAULT(0)"            \
         ");";
 
     # Create desc table
@@ -16,7 +16,7 @@ BEGIN {
 }
 
     # Insert data into english table
-    {   printf "INSERT INTO english (word, freq) VALUES (\"%s\", %f);\n", $1, $2}
+    {   printf "INSERT INTO english (word, freq) VALUES ('%s', %f);\n", $1, $2}
 
     #quit sqlite3
 END {

--- a/data/table.awk
+++ b/data/table.awk
@@ -21,7 +21,7 @@ BEGIN {
 
 # Insert data into phrases table
 NF == 4 {
-    printf "INSERT INTO phrases (id, tabkeys, phrase) VALUES (%d, \"%s\", \"%s\");\n", id, $3, $1;
+    printf "INSERT INTO phrases (id, tabkeys, phrase) VALUES (%d, '%s', '%s');\n", id, $3, $1;
     id++;
 }
 


### PR DESCRIPTION
 The SQL standard requires double-quotes around identifiers and single-quotes around string literals. For example:

    "this is a legal SQL column name"
    'this is an SQL string literal'

With sqlite 3.41.0, this is being enforced on the CLI
