### PR TITLE
Fix Compile error with >=sqlite-3.41.0

### DIFF
--- a/data/english.awk
+++ b/data/english.awk
@@ -16,7 +16,7 @@ BEGIN {
 }
 
     # Insert data into english table
-    {   printf "INSERT INTO english (word, freq) VALUES (\"%s\", %f);\n", $1, $2}
+    {   printf "INSERT INTO english (word, freq) VALUES (\'%s\', %f);\n", $1, $2}
 
     #quit sqlite3
 END {

--- a/data/table.awk
+++ b/data/table.awk
@@ -21,7 +21,7 @@ BEGIN {
 
 # Insert data into phrases table
 NF == 4 {
-    printf "INSERT INTO phrases (id, tabkeys, phrase) VALUES (%d, \"%s\", \"%s\");\n", id, $3, $1;
+    printf "INSERT INTO phrases (id, tabkeys, phrase) VALUES (%d, \'%s\', \'%s\');\n", id, $3, $1;
     id++;
 }
 


### PR DESCRIPTION
data/english.awk run failed with sqlite 3.41.0, the error
message is:
```
make[3]: Entering directory '/var/tmp/portage/app-i18n/ibus-libpinyin-1.13.1/work/ibus-l
ibpinyin-1.13.1/data'
\
rm -f english.db; \
gawk -f ./english.awk ./wordlist | /usr/bin/sqlite3 english.db || \
        ( rm -f english.db ; exit 1 )
Parse error near line 5: no such column: the
  INSERT INTO english (word, freq) VALUES ("the", 6.510891);
                             error here ---^
```

As sqlite 3.41.0 release note say:

The double-quoted string misfeature is now disabled by default for CLI builds. Legacy use cases can reenable the misfeature at run-time using the ".dbconfig dqs_dml on" and ".dbconfig dqs_ddl on" commands.