### PR TITLE
fix(wordlist): remove word hitler

### DIFF
--- a/data/wordlist
+++ b/data/wordlist
@@ -4772,7 +4772,6 @@ implemented	0.001838
 excessive	0.001838
 iraqi	0.001837
 enterprises	0.001837
-hitler	0.001836
 dining	0.001836
 exceptional	0.001836
 greece	0.001835
@@ -21953,7 +21952,6 @@ Harrogate	0.000769
 Hartley	0.000294
 Hegel	0.000251
 Herr	0.000609
-Hitler	0.001836
 Honduras	0.000222
 Horne	0.000316
 HP	0.001127


### PR DESCRIPTION
## Description
For the sake of anti-fascism, the word `[Hh]itler` should be removed from the word list. Or if removing it from the word list is unacceptable, its frequency should be no higher than the word `[Hh]i`. Currently its frequency tops the words starting with `Hi*`. Otherwise when users are typing "Hi", the first suggested English word candidate will be `Hitler` instead of `Hi`, nor any other words that make more sense. 

## Issue statement
The screenshot shows the English word suggestion candidates when "Hi" is typed on a fresh installation of this IME without any wording preference set.
![Screenshot from 2024-09-06 00-14-19](https://github.com/user-attachments/assets/8acb4d18-be6e-4748-bbb9-3fb1ca7cd990)
