### PR TITLE
Fix compiler error with clang 19

### DIFF
--- a/src/PYLibPinyin.h
+++ b/src/PYLibPinyin.h
@@ -24,6 +24,7 @@
 #include <memory>
 #include <time.h>
 #include <glib.h>
+#include <stdio.h>
 
 typedef struct _pinyin_context_t pinyin_context_t;
 typedef struct _pinyin_instance_t pinyin_instance_t;


### PR DESCRIPTION

    This commit fixes the following compiler error.
    
    src/PYLibPinyin.h:53:32: error: unknown type name 'FILE'
       53 |     gboolean exportUserPhrase (FILE *dictfile);
          |                                ^
