### PR TITLE
Fixed bug when switching to Chinese after non-Latin layout

### DIFF
--- a/src/default.inputmethod.xml.in.in
+++ b/src/default.inputmethod.xml.in.in
@@ -11,7 +11,7 @@
 	BYVoid &lt;byvoid1@gmail.com&gt;
 	</author>
 	<icon>@PKGDATADIR@/icons/ibus-pinyin.svg</icon>
-	<layout>default</layout>
+	<layout>cn</layout>
 	<longname>Intelligent Pinyin</longname>
 	<description>Intelligent Pinyin input method</description>
 	<rank>99</rank>
@@ -31,7 +31,7 @@
 	BYVoid &lt;byvoid1@gmail.com&gt;
 	</author>
 	<icon>@PKGDATADIR@/icons/ibus-bopomofo.svg</icon>
-	<layout>default</layout>
+	<layout>cn</layout>
 	<longname>Bopomofo</longname>
 	<description>Bopomofo input method</description>
 	<rank>98</rank>


### PR DESCRIPTION
Greetings,

I have multiple keyboard layouts, and I've noticed that when I switch to Chinese layout after non-Latin layout, e.g. Russian or Belarusian, I can only type Cyrillic letters and cannot use pinyin: it simply does not get triggered. But now I've fixed that

For those who need an immediate solution, there is a quick fix:

```bash
sed "s/<layout>default<\/layout>/<layout>cn<\/layout>/g" /usr/share/ibus/component/libpinyin.xml | sudo tee /usr/share/ibus/component/libpinyin.xml
```

Debian trixie/sid
ibus-libpinyin version 1.15.8-2