### PR TITLE
Disable simplified and traditional switch in English input mode.

### DIFF
--- a/src/PYPinyinProperties.cc
+++ b/src/PYPinyinProperties.cc
@@ -145,6 +145,9 @@ PinyinProperties::toggleModeChinese (void)
     
     m_prop_full_punct.setSensitive (m_mode_chinese);
     updateProperty (m_prop_full_punct);
+
+    m_prop_simp.setSensitive (m_mode_chinese);
+    updateProperty (m_prop_simp);
 }
 
 void


### PR DESCRIPTION
Hi @epico :
I found that in the English input mode, user still could click the simp->traditional switch. But it is not expected to take effects. I think the right way is only enable it on ZH input. what's your opinion? Please take a review?
Thank you so much for your time!

![before](https://github.com/user-attachments/assets/c89e1325-44ce-4f39-af37-99f9f4bbac3f)

![after](https://github.com/user-attachments/assets/ca0abdc4-f807-42c0-b222-e04b96d132ab)
