### PR TITLE
Fix import/outport data default from program dir.

### DIFF
--- a/setup/main2.py
+++ b/setup/main2.py
@@ -496,6 +496,8 @@ class PreferencesDialog:
         dialog.add_buttons(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
                            Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
 
+        dialog.set_current_folder(os.path.expanduser("~"))
+
         filter_text = Gtk.FileFilter()
         filter_text.set_name("Text files")
         filter_text.add_mime_type("text/plain")
@@ -516,6 +518,8 @@ class PreferencesDialog:
 
         dialog.add_buttons(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
                            Gtk.STOCK_SAVE, Gtk.ResponseType.OK)
+
+        dialog.set_current_folder(os.path.expanduser("~"))
 
         dialog.set_do_overwrite_confirmation(True)
 


### PR DESCRIPTION
Hi @epico 
Currently, the import and outport user dictionary default from the setup program dir, I suppose it should from user's home in the first place. This will convenient for users to a large extent. What your opinion?
Thank you so much for your time to review. :-)

![2](https://github.com/user-attachments/assets/79de90ae-9021-4896-83c1-69b4475c153c)