### PR TITLE
Fix european locales unable to make and install

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -48,13 +48,13 @@ auxiliary_dbdir = $(pkgdatadir)/db
 $(ENGLISH_DB): $(WORDLIST) $(ENGLISH_AWK)
 	$(AM_V_GEN) \
 	$(RM) $@; \
-	$(AWK) -f $(srcdir)/$(ENGLISH_AWK) $(srcdir)/$(WORDLIST) | @SQLITE3@ $@ || \
+	LC_NUMERIC=C $(AWK) -f $(srcdir)/$(ENGLISH_AWK) $(srcdir)/$(WORDLIST) | @SQLITE3@ $@ || \
 		( $(RM) $@ ; exit 1 )
 
 $(TABLE_DB): $(TABLE) $(TABLE_AWK)
 	$(AM_V_GEN) \
 	$(RM) $@; \
-	$(AWK) -f $(srcdir)/$(TABLE_AWK) $(srcdir)/$(TABLE) | @SQLITE3@ $@ || \
+	LC_NUMERIC=C $(AWK) -f $(srcdir)/$(TABLE_AWK) $(srcdir)/$(TABLE) | @SQLITE3@ $@ || \
 		( $(RM) $@ ; exit 1 )
 
 appdatadir = @datadir@/metainfo


### PR DESCRIPTION
In most european countries, a comma is used to denote decimal numbers instead of a period. This confuses SQLite into thinking there are 3 columns instead of 2 and throws an error, since the comma for decimal is interpreted as a separator between columns.

This commit fixes the problem and allows the program to be built under any locale.